### PR TITLE
Caster as a Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup,find_packages
+with open("README.md","r") as rm:
+    long_d=rm.read()
+with open("LICENSE.md","r") as lc:
+    _license=lc.read()
+setup(
+    name="caster",
+    version="0.5.10",
+    author="synkarius",
+    packages=find_packages(exclude=("user",)),
+    long_description=long_d,
+    license=_license,
+    url= "https://github.com/synkarius/caster",
+    install_requires=[
+        "pywin32;platform_system=='Windows'",
+        "git+ssh://git@github.com/Danesprite/dragonfly.git",
+
+        "Pillow",
+    ],
+
+)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@ setup(
     url= "https://github.com/synkarius/caster",
     install_requires=[
         "pywin32;platform_system=='Windows'",
-        "git+ssh://git@github.com/Danesprite/dragonfly.git",
+        
 
         "Pillow",
     ],
+    dependency_links=[
+        "git+ssh://git@github.com/Danesprite/dragonfly.git#egg=dragonfly",
+    ]
 
 )


### PR DESCRIPTION
This is a preliminary pull request which will eventually include everything required to make caster a Python package. It is not ready for testing due to requiring changes to settings.py.

 The setup.py file will install the lib,asynch sub packages into the installed python packages. This eliminates the annoying import error messages when debugging caster modules and will eventually lead to the splitting of caster into 2 parts:

1. **The user space**, which will include user specific configuration files like settings.json and the user package which allows for the creation and application of new grammars and filters.
2. **The framework space**, which will be installed as a Python package and will contain the "backend", namely the default grammars, the base caster engine modules and caster utilities like the mouse grids.

Things required:

-Modify settings.py paths to point to the correct locations
-Store user data in an appropriate location
Feedback required on:
-The proposed new file structure for caster
-Other suggestions for the setup file
