### PR TITLE
Partial fix for the non-ASCII text in clipboard slots bug

### DIFF
--- a/caster/lib/context.py
+++ b/caster/lib/context.py
@@ -144,7 +144,7 @@ def paste_string_without_altering_clipboard(content):
     cb = Clipboard(from_system=True)
 
     try:
-        Clipboard.set_system_text(str(content))
+        Clipboard.set_system_text(unicode(content))
 
         Key("c-v").execute()
         time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/


### PR DESCRIPTION
Workaround for #357. Use Unicode with the clipboard; substitute `\x` with nonprintable characters. Removes repeated code