### PR TITLE
Choice from toml files

### DIFF
--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -18,6 +18,7 @@ from _winreg import (CloseKey, ConnectRegistry, HKEY_CLASSES_ROOT,
     HKEY_CURRENT_USER, OpenKey, QueryValueEx)
 
 from dragonfly.windows.window import Window
+from dragonfly import Choice
 
 try:  # Style C -- may be imported into Caster, or externally
     BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
@@ -92,6 +93,14 @@ def load_toml_file(path):
         simple_log(True)
     return result
 
+def Choice_from_file(name, paths):
+    if type(paths) is str:
+        paths = [paths]
+    phrases = {}
+    for path in paths:
+        path = BASE_PATH + "/" + path
+        phrases.update(load_toml_file(path)[name])
+    return Choice(name, phrases)
 
 def list_to_string(l):
     return u"\n".join([unicode(x) for x in l])

--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -93,14 +93,24 @@ def load_toml_file(path):
         simple_log(True)
     return result
 
-def Choice_from_file(name, paths):
-    if type(paths) is str:
-        paths = [paths]
+'''
+Takes a choice name and an arbitrary number of toml path/label
+pair lists. For example:
+mapping["<alphanumeric>"] = Text("%(alphanumeric)s")
+extras = [
+    utilities.Choice_from_file("alphanumeric",
+     ["caster/.../alphabet.toml", "letters"], 
+     ["caster/.../alphabet.toml", "numbers"]
+     )
+]
+'''
+def Choice_from_file(name, *args):
     phrases = {}
-    for path in paths:
-        path = BASE_PATH + "/" + path
-        phrases.update(load_toml_file(path)[name])
+    for arg in args:
+        path = BASE_PATH + "/" + arg[0]
+        phrases.update(load_toml_file(path)[arg[1]])
     return Choice(name, phrases)
+
 
 def list_to_string(l):
     return u"\n".join([unicode(x) for x in l])

--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -78,37 +78,26 @@ def save_toml_file(data, path):
     except Exception:
         simple_log(True)
 
-
-def load_toml_file(path):
+# Load the target file if it exists. If not, create it and
+# fill it with the backupdict, if provided.
+def load_toml_file(path, backupdict=None):
     result = {}
     try:
         with io.open(path, "rt", encoding="utf-8") as f:
             result = toml.loads(f.read())
     except IOError as e:
         if e.errno == 2:  # The file doesn't exist.
-            save_toml_file(result, path)
+            print(path + " does not exist, recovering...")
+            if backupdict:
+                save_toml_file(backupdict, path)
+                return backupdict
+            else:
+                save_toml_file(result, path)
         else:
             raise
     except Exception:
         simple_log(True)
     return result
-
-'''
-Takes a choice name and an arbitrary number of toml path/label
-pair lists. For example:
-mapping["<alphanumeric>"] = Text("%(alphanumeric)s")
-extras = [
-    utilities.Choice_from_file("alphanumeric",
-     [utilities.get_full_path("caster/.../alphabet.toml"), "letters"], 
-     [utilities.get_full_path("caster/.../alphabet.toml"), "numbers"]
-     )
-]
-'''
-def Choice_from_file(name, *args):
-    phrases = {}
-    for arg in args:
-        phrases.update(load_toml_file(arg[0])[arg[1]])
-    return Choice(name, phrases)
 
 # takes e.g. "caster/.../file.extension" and returns a full path
 def get_full_path(path):

--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -99,18 +99,20 @@ pair lists. For example:
 mapping["<alphanumeric>"] = Text("%(alphanumeric)s")
 extras = [
     utilities.Choice_from_file("alphanumeric",
-     ["caster/.../alphabet.toml", "letters"], 
-     ["caster/.../alphabet.toml", "numbers"]
+     [utilities.get_full_path("caster/.../alphabet.toml"), "letters"], 
+     [utilities.get_full_path("caster/.../alphabet.toml"), "numbers"]
      )
 ]
 '''
 def Choice_from_file(name, *args):
     phrases = {}
     for arg in args:
-        path = BASE_PATH + "/" + arg[0]
-        phrases.update(load_toml_file(path)[arg[1]])
+        phrases.update(load_toml_file(arg[0])[arg[1]])
     return Choice(name, phrases)
 
+# takes e.g. "caster/.../file.extension" and returns a full path
+def get_full_path(path):
+    return BASE_PATH + "/" + path
 
 def list_to_string(l):
     return u"\n".join([unicode(x) for x in l])


### PR DESCRIPTION
Utility function to allow the import of Choice elements from one or more toml files. e.g.
```
extras = [
    Choice_from_file("symbol", "caster/ccr/latex/latex.toml"),
]
```
where the toml file looks like:
```
[symbol]
"symbol one" = "symbol one"
...
```

At the moment I'm just thinking about using this to de-clutter a couple of the language modules, but potentially it could also be used for importing from user space, simply by passing a list of paths rather than just one.