### PR TITLE
Text formatting bug fixes

### DIFF
--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -136,32 +136,31 @@ def cut_keep_clipboard(nnavi500, nexus):
 
 
 def drop_keep_clipboard(nnavi500, nexus, capitalization, spacing):
-    if capitalization != 0 or spacing != 0 or nnavi500 != 1:
-        cb = Clipboard(from_system=True)
-        if nnavi500 > 1:
-            key = str(nnavi500)
-            if key in nexus.clip:
-                text = nexus.clip[key]
-            else:
-                dragonfly.get_engine().speak("slot empty")
-                text = None
+    # Maintain standard spark functionality for non-strings
+    if capitalization == 0 and spacing == 0 and nnavi500 == 1:
+        Key("c-v").execute()
+        return
+    # Get clipboard text
+    if nnavi500 > 1:
+        key = str(nnavi500)
+        if key in nexus.clip:
+            text = nexus.clip[key]
         else:
-            text = Clipboard.get_system_text()
-
-        # Paste clipboard contents if the slot wasn't empty.
-        if text is not None:
-            formatted = textformat.TextFormat.formatted_text(capitalization, spacing, text)
-            Clipboard.set_system_text(formatted)
-            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-            Key("c-v").execute()
-            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-
+            dragonfly.get_engine().speak("slot empty")
+            text = None
+    else:
+        text = Clipboard.get_system_text()
+    # Format if necessary, and paste
+    if text is not None:
+        cb = Clipboard(from_system=True)
+        if capitalization != 0 or spacing != 0:
+            text = textformat.TextFormat.formatted_text(capitalization, spacing, text)
+        Clipboard.set_system_text(text)
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        Key("c-v").execute()
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
         # Restore the clipboard contents.
         cb.copy_to_system()
-
-    # Maintain standard spark functionality for non-strings
-    else:
-        Key("c-v").execute()
 
 
 def duple_keep_clipboard(nnavi50):

--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -28,6 +28,10 @@ class TextFormat():
 
     @classmethod
     def formatted_text(cls, capitalization, spacing, t):
+        if capitalization == 0:
+            capitalization = 5
+        if spacing == 0 and capitalization == 3:
+            spacing = 1
         tlen = len(t)
         if capitalization != 0:
             if capitalization == 1:

--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -28,10 +28,6 @@ class TextFormat():
 
     @classmethod
     def formatted_text(cls, capitalization, spacing, t):
-        if capitalization == 0:
-            capitalization = 5
-        if spacing == 0 and capitalization == 3:
-            spacing = 1
         tlen = len(t)
         if capitalization != 0:
             if capitalization == 1:


### PR DESCRIPTION
1. Fixed a bug whereby formats would not be normalised before being executed, so for example "gerrish bow" would produce "some Text" rather than "someText".
2. Fixed a bug resulting from the above bug fix, whereby pasting from the Caster clipboard without specifying a format would automatically produce lowercase text. Clarified the logic of the paste command.