### PR TITLE
Text normalization bug fix

### DIFF
--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -1,10 +1,7 @@
-import time
-import sys
+from builtins import str
 
-from caster.lib.actions import Key, Text
-from caster.lib.clipboard import Clipboard
-from caster.lib import settings, context
 from caster.lib import settings
+from caster.lib.actions import Text
 
 
 class TextFormat():
@@ -28,18 +25,13 @@ class TextFormat():
 
     @classmethod
     def formatted_text(cls, capitalization, spacing, t):
-        tlen = len(t)
         if capitalization != 0:
             if capitalization == 1:
                 t = t.upper()
             elif capitalization == 2:
                 t = t.title()
             elif capitalization == 3:
-                if tlen > 1:
-                    t = t.title()
-                    t = t[0].lower() + t[1:]
-                else:
-                    t = t[0].lower()
+                t = t[0].lower() + t.title()[1:]
             elif capitalization == 4:
                 t = t.capitalize()
             elif capitalization == 5:
@@ -62,13 +54,28 @@ class TextFormat():
     @classmethod
     def get_text_format_description(cls, capitalization, spacing):
         caps = {0: "<none>", 1: "yell", 2: "tie", 3: "gerrish", 4: "sing", 5: "laws"}
-        spaces = {0: "<none>", 1: "gum", 2: "spine", 3: "snake",
-                  4: "pebble", 5: "incline", 6: "descent"}
+        spaces = {
+            0: "<none>",
+            1: "gum",
+            2: "spine",
+            3: "snake",
+            4: "pebble",
+            5: "incline",
+            6: "descent"
+        }
         if capitalization == 0 and spacing == 0:
             return "<none>"
         else:
             text = cls.formatted_text(capitalization, spacing, str("this is a test"))
             return "%s %s (%s)" % (caps[capitalization], spaces[spacing], text)
+
+    @classmethod
+    def normalize_text_format(cls, capitalization, spacing):
+        if capitalization == 0:
+            capitalization = 5
+        if spacing == 0 and capitalization == 3:
+            spacing = 1
+        return (capitalization, spacing)
 
     def __init__(self, default_cap, default_spacing):
         self.default_cap = default_cap
@@ -76,16 +83,9 @@ class TextFormat():
         self.capitalization = 0
         self.spacing = 0
 
-    def _normalize_text_format(self):
-        if self.capitalization == 0:
-            self.capitalization = 5
-        if self.spacing == 0 and self.capitalization == 3:
-            self.spacing = 1
-
     def set_text_format(self, capitalization, spacing):
-        self.capitalization = capitalization
-        self.spacing = spacing
-        self._normalize_text_format()
+        self.capitalization, self.spacing = self.normalize_text_format(
+            capitalization, spacing)
 
     def clear_text_format(self):
         self.capitalization = self.default_cap
@@ -99,26 +99,37 @@ class TextFormat():
 
 
 format = TextFormat(*settings.SETTINGS["formats"]["_default"]["text_format"])
-secondary_format = TextFormat(*settings.SETTINGS["formats"]["_default"]["secondary_format"])
+secondary_format = TextFormat(
+    *settings.SETTINGS["formats"]["_default"]["secondary_format"])
+
 
 def _choose_format(big):
     return format if not big else secondary_format
+
 
 # module interface
 def set_text_format(big, capitalization, spacing):
     _choose_format(big).set_text_format(capitalization, spacing)
 
+
 def clear_text_format(big):
     _choose_format(big).clear_text_format()
+
 
 def peek_text_format(big):
     print("Text formatting: %s" % str(_choose_format(big)))
 
+
 def partial_format_text(big, word_limit, textnv):
-    Text(_choose_format(big).get_formatted_text(" ".join(str(textnv).split(" ")[0:word_limit]))).execute()
+    Text(
+        _choose_format(big).get_formatted_text(" ".join(
+            str(textnv).split(" ")[0:word_limit]))).execute()
+
 
 def prior_text_format(big, textnv):
     Text(_choose_format(big).get_formatted_text(str(textnv))).execute()
 
+
 def master_format_text(capitalization, spacing, textnv):
+    capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
     Text(TextFormat.formatted_text(capitalization, spacing, str(textnv))).execute()


### PR DESCRIPTION
This was my solution to the issue addressed by @mrob95 in #368. I've been sitting on this for a while, as can be seen from the date in the branch name.

The tactic I took solving this was to simply apply the existing normalization to dictated text. There are several more extensive changes I would like to make in this area, but I thought this was an acceptable minimum for fixing the bug. I explicitly wanted to avoid messing with paste functionality due to that being part of the larger scope of changes I would like to make in the future.

The meaningful changes are:
 * Line 1 makes `str` Unicode. This is important to be able to handle the (currently optional) changes to the Windows implementation of `Text` in Dragonfly. This section also has some basic cleanup of the imports.
 * Line 34 is a simplification of `formatted_text` to remove an unnecessary length test.
 * Lines 72-79 turns `_normalize_text_format` into class method `normalize_text_format`.
 * Lines 87 and 88 convert `set_text_format` to use the new `normalize_text_format` class method.
 * Line 134 does the same for `master_format_text`.

Everything else is noise introduced from `yapf` processing.

I'm open to merging whichever pull request others are most satisfied with. #368 is a more obvious and straightforward solution. My code allows `format_text` to be called without forcing normalization. 