### PR TITLE
Alias updates

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -158,7 +158,7 @@ if settings.SETTINGS["feature_rules"]["again"]:
     grammar.add_rule(again_rule)
 
 if settings.SETTINGS["feature_rules"]["alias"]:
-    alias_rule = Alias(name="alias")
+    alias_rule = Alias(_NEXUS)
     gfilter.run_on(alias_rule)
     grammar.add_rule(alias_rule)
 

--- a/caster/lib/dfplus/merge/selfmodrule.py
+++ b/caster/lib/dfplus/merge/selfmodrule.py
@@ -46,7 +46,7 @@ class SelfModifyingRule(MergeRule):
             grammar.remove_rule(self)
 
         extras = self.extras if self.extras else [IntegerRefST("n", 1, 50), Dictation("s")]
-        defaults = self.defaults if self.defaults else { "n": 1 }
+        defaults = self.defaults if self.defaults else { "n": 1, "s": "" }
         MergeRule.__init__(self, self.name, mapping, extras, defaults, self.exported,
                            self.context)
 


### PR DESCRIPTION
Re #358 

* Removed CCR from regular alias
* Both regular aliases and chain aliases can now be added both with a voice command and through the GUI. "alias example command" will set the spec as "example command". "alias" will bring up the GUI.

Seems like an intuitive way of doing things but I'm happy to take suggestions.