### PR TITLE
Implemented Accessibility API

### DIFF
--- a/castervoice/apps/accessibilityapi.py
+++ b/castervoice/apps/accessibilityapi.py
@@ -7,21 +7,21 @@ WIP - Included as a App As it only works with certain applications.
 """
 #---------------------------------------------------------------------------
 
-from dragonfly import (Grammar, Dictation, Repeat)
+from dragonfly import (Grammar, Dictation, Function, Compound, Alternative, Literal, CursorPosition, TextQuery)
+from dragonfly import get_accessibility_controller
 
 from castervoice.lib import control
 from castervoice.lib import settings
-from castervoice.lib.actions import Key, Mouse
 from castervoice.lib.context import AppContext
-from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.merge import gfilter
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
-from castervoice.lib.dfplus.state.short import R
 
 accessibility = get_accessibility_controller()
 
 class AccessibilityRule(MergeRule):
     pronunciation = "notepad plus plus"
+
+    mapping = {
 
 # Accessibility API Mappings
     "go before <text_position_query>": Function(
@@ -76,17 +76,18 @@ class AccessibilityRule(MergeRule):
         end_relative_phrase=str(extras["relative_phrase"])))
     ]
 
+    defaults = {
 
-#---------------------------------------------------------------------------
+    }
 
-context = AppContext(executable="chrome") \ 
+context = AppContext(executable="chrome") \
     | AppContext(executable="firefox") \
     | AppContext(executable="gitter") \
     | AppContext(executable="discord")
 
 grammar = Grammar("AccessibilityAPI", context=context)
 
-if settings.SETTINGS["apps"]["AccessibilityAPI"]:
+if settings.SETTINGS["apps"]["accessibilityapi"]:
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
         control.nexus().merger.add_global_rule(AccessibilityRule())
     else:

--- a/castervoice/apps/accessibilityapi.py
+++ b/castervoice/apps/accessibilityapi.py
@@ -1,0 +1,96 @@
+"""
+Credit to Wolfmanstout
+Command-module for Accessibility API
+http://handsfreecoding.org/2018/12/27/enhanced-text-manipulation-using-accessibility-apis/
+
+WIP - Included as a App As it only works with certain applications. 
+"""
+#---------------------------------------------------------------------------
+
+from dragonfly import (Grammar, Dictation, Repeat)
+
+from castervoice.lib import control
+from castervoice.lib import settings
+from castervoice.lib.actions import Key, Mouse
+from castervoice.lib.context import AppContext
+from castervoice.lib.dfplus.additions import IntegerRefST
+from castervoice.lib.dfplus.merge import gfilter
+from castervoice.lib.dfplus.merge.mergerule import MergeRule
+from castervoice.lib.dfplus.state.short import R
+
+accessibility = get_accessibility_controller()
+
+class AccessibilityRule(MergeRule):
+    pronunciation = "notepad plus plus"
+
+# Accessibility API Mappings
+    "go before <text_position_query>": Function(
+        lambda text_position_query: accessibility.move_cursor(
+            text_position_query, CursorPosition.BEFORE)),
+    "go after <text_position_query>": Function(
+        lambda text_position_query: accessibility.move_cursor(
+            text_position_query, CursorPosition.AFTER)),
+    "words <text_query>": Function(accessibility.select_text),
+    "words <text_query> delete": Function(
+        lambda text_query: accessibility.replace_text(text_query, "")),
+    "replace <text_query> with <replacement>": Function(
+        accessibility.replace_text),
+
+    }
+    extras = [
+    Dictation("replacement"),
+    Compound(
+    name="text_query",
+    spec=("[[([<start_phrase>] <start_relative_position> <start_relative_phrase>|<start_phrase>)] <through>] "
+            "([<end_phrase>] <end_relative_position> <end_relative_phrase>|<end_phrase>)"),
+    extras=[Dictation("start_phrase", default=""),
+    Alternative([Literal("before"), Literal("after")],
+        name="start_relative_position"),
+    Dictation("start_relative_phrase", default=""),
+    Literal("through", "through", value=True, default=False),
+    Dictation("end_phrase", default=""),
+    Alternative([Literal("before"), Literal("after")],
+        name="end_relative_position"),
+    Dictation("end_relative_phrase", default="")],
+        value_func=lambda node, extras: TextQuery(
+        start_phrase=str(extras["start_phrase"]),
+        start_relative_position=(CursorPosition[extras["start_relative_position"].upper()]
+            if "start_relative_position" in extras else None),
+        start_relative_phrase=str(extras["start_relative_phrase"]),
+        through=extras["through"],
+        end_phrase=str(extras["end_phrase"]),
+        end_relative_position=(CursorPosition[extras["end_relative_position"].upper()]
+            if "end_relative_position" in extras else None),
+        end_relative_phrase=str(extras["end_relative_phrase"]))),
+    Compound(
+        name="text_position_query",
+        spec="<phrase> [<relative_position> <relative_phrase>]",
+        extras=[Dictation("phrase", default=""),
+    Alternative([Literal("before"), Literal("after")],
+        name="relative_position"),
+    Dictation("relative_phrase", default="")],
+        value_func=lambda node, extras: TextQuery(
+        end_phrase=str(extras["phrase"]),
+        end_relative_position=(CursorPosition[extras["relative_position"].upper()]
+            if "relative_position" in extras else None),
+        end_relative_phrase=str(extras["relative_phrase"])))
+    ]
+
+
+#---------------------------------------------------------------------------
+
+context = AppContext(executable="chrome") \ 
+    | AppContext(executable="firefox") \
+    | AppContext(executable="gitter") \
+    | AppContext(executable="discord")
+
+grammar = Grammar("AccessibilityAPI", context=context)
+
+if settings.SETTINGS["apps"]["AccessibilityAPI"]:
+    if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
+        control.nexus().merger.add_global_rule(AccessibilityRule())
+    else:
+        rule = AccessibilityRule(name="accessibility rule")
+        gfilter.run_on(rule)
+        grammar.add_rule(rule)
+        grammar.load()

--- a/castervoice/apps/accessibilityapi.py
+++ b/castervoice/apps/accessibilityapi.py
@@ -5,7 +5,7 @@ http://handsfreecoding.org/2018/12/27/enhanced-text-manipulation-using-accessibi
 
 WIP - Included as a App As it only works with certain applications. 
 """
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 from dragonfly import (Grammar, Dictation, Function, Compound, Alternative, Literal, CursorPosition, TextQuery)
 from dragonfly import get_accessibility_controller
@@ -18,72 +18,74 @@ from castervoice.lib.dfplus.merge.mergerule import MergeRule
 
 accessibility = get_accessibility_controller()
 
+
 class AccessibilityRule(MergeRule):
     pronunciation = "notepad plus plus"
 
     mapping = {
 
-# Accessibility API Mappings
-    "go before <text_position_query>": Function(
-        lambda text_position_query: accessibility.move_cursor(
-            text_position_query, CursorPosition.BEFORE)),
-    "go after <text_position_query>": Function(
-        lambda text_position_query: accessibility.move_cursor(
-            text_position_query, CursorPosition.AFTER)),
-    "words <text_query>": Function(accessibility.select_text),
-    "words <text_query> delete": Function(
-        lambda text_query: accessibility.replace_text(text_query, "")),
-    "replace <text_query> with <replacement>": Function(
-        accessibility.replace_text),
+        # Accessibility API Mappings
+        "go before <text_position_query>": Function(
+            lambda text_position_query: accessibility.move_cursor(
+                text_position_query, CursorPosition.BEFORE)),
+        "go after <text_position_query>": Function(
+            lambda text_position_query: accessibility.move_cursor(
+                text_position_query, CursorPosition.AFTER)),
+        "words <text_query>": Function(accessibility.select_text),
+        "words <text_query> delete": Function(
+            lambda text_query: accessibility.replace_text(text_query, "")),
+        "replace <text_query> with <replacement>": Function(
+            accessibility.replace_text),
 
     }
     extras = [
-    Dictation("replacement"),
-    Compound(
-    name="text_query",
-    spec=("[[([<start_phrase>] <start_relative_position> <start_relative_phrase>|<start_phrase>)] <through>] "
-            "([<end_phrase>] <end_relative_position> <end_relative_phrase>|<end_phrase>)"),
-    extras=[Dictation("start_phrase", default=""),
-    Alternative([Literal("before"), Literal("after")],
-        name="start_relative_position"),
-    Dictation("start_relative_phrase", default=""),
-    Literal("through", "through", value=True, default=False),
-    Dictation("end_phrase", default=""),
-    Alternative([Literal("before"), Literal("after")],
-        name="end_relative_position"),
-    Dictation("end_relative_phrase", default="")],
-        value_func=lambda node, extras: TextQuery(
-        start_phrase=str(extras["start_phrase"]),
-        start_relative_position=(CursorPosition[extras["start_relative_position"].upper()]
-            if "start_relative_position" in extras else None),
-        start_relative_phrase=str(extras["start_relative_phrase"]),
-        through=extras["through"],
-        end_phrase=str(extras["end_phrase"]),
-        end_relative_position=(CursorPosition[extras["end_relative_position"].upper()]
-            if "end_relative_position" in extras else None),
-        end_relative_phrase=str(extras["end_relative_phrase"]))),
-    Compound(
-        name="text_position_query",
-        spec="<phrase> [<relative_position> <relative_phrase>]",
-        extras=[Dictation("phrase", default=""),
-    Alternative([Literal("before"), Literal("after")],
-        name="relative_position"),
-    Dictation("relative_phrase", default="")],
-        value_func=lambda node, extras: TextQuery(
-        end_phrase=str(extras["phrase"]),
-        end_relative_position=(CursorPosition[extras["relative_position"].upper()]
-            if "relative_position" in extras else None),
-        end_relative_phrase=str(extras["relative_phrase"])))
+        Dictation("replacement"),
+        Compound(
+            name="text_query",
+            spec=("[[([<start_phrase>] <start_relative_position> <start_relative_phrase>|<start_phrase>)] <through>] "
+                  "([<end_phrase>] <end_relative_position> <end_relative_phrase>|<end_phrase>)"),
+            extras=[Dictation("start_phrase", default=""),
+                    Alternative([Literal("before"), Literal("after")],
+                                name="start_relative_position"),
+                    Dictation("start_relative_phrase", default=""),
+                    Literal("through", "through", value=True, default=False),
+                    Dictation("end_phrase", default=""),
+                    Alternative([Literal("before"), Literal("after")],
+                                name="end_relative_position"),
+                    Dictation("end_relative_phrase", default="")],
+            value_func=lambda node, extras: TextQuery(
+                start_phrase=str(extras["start_phrase"]),
+                start_relative_position=(CursorPosition[extras["start_relative_position"].upper()]
+                                         if "start_relative_position" in extras else None),
+                start_relative_phrase=str(extras["start_relative_phrase"]),
+                through=extras["through"],
+                end_phrase=str(extras["end_phrase"]),
+                end_relative_position=(CursorPosition[extras["end_relative_position"].upper()]
+                                       if "end_relative_position" in extras else None),
+                end_relative_phrase=str(extras["end_relative_phrase"]))),
+        Compound(
+            name="text_position_query",
+            spec="<phrase> [<relative_position> <relative_phrase>]",
+            extras=[Dictation("phrase", default=""),
+                    Alternative([Literal("before"), Literal("after")],
+                                name="relative_position"),
+                    Dictation("relative_phrase", default="")],
+            value_func=lambda node, extras: TextQuery(
+                end_phrase=str(extras["phrase"]),
+                end_relative_position=(CursorPosition[extras["relative_position"].upper()]
+                                       if "relative_position" in extras else None),
+                end_relative_phrase=str(extras["relative_phrase"])))
     ]
 
     defaults = {
 
     }
 
+
 context = AppContext(executable="chrome") \
-    | AppContext(executable="firefox") \
-    | AppContext(executable="gitter") \
-    | AppContext(executable="discord")
+          | AppContext(executable="firefox") \
+          | AppContext(executable="gitter") \
+          | AppContext(executable="discord")
 
 grammar = Grammar("AccessibilityAPI", context=context)
 

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -263,6 +263,7 @@ _DEFAULT_SETTINGS = {
         "visualstudiocode": True,
         "winword": True,
         "wsr": True,
+        "accessibilityapi": True,
     },
 
     # python settings


### PR DESCRIPTION
Info on what this is and what this does can be found on [Hands Free Coding](http://handsfreecoding.org/2018/12/27/enhanced-text-manipulation-using-accessibility-apis/ ). Credit for the goes Wolfmanstout

**Note**
Follow the install instructions on in the link above for the Accessibility API.

Works for Chrome, Firefox, Discord, and Gitter

-  To test ` words <dictation>` Command will highlight/select the dictated text. For example:

   1. Open an application and click on a field that accepts text. Say `this is a test`.

   2. Say the command `words <is>`. In `this is a test` the word `is` will be highlighted.

Natlink Window print out results

- Supported Application

`accessibility: Selecting text: {'end_phrase': 'is'}`
`accessibility: Selected text`

- Unsupported application or nonfunctioning api

`accessibility: Selecting text: {'end_phrase': 'is'}`
`accessibility: Nothing is focused.`

**Known issues - Needs further testing by the community**

It works intermittently for some programs. It's bulletproof for Firefox and Chrome. However for gitter and discord the API seems to be sporadic. When it does work for those two applications works until Dragon is restarted. Functionality is all or nothing. For example, If it works in gitter then likewise discord or not at all in those applications. Firefox and Chrome are unaffected. I need more people to test the Accessibility API to confirm.

**Want to test API compatibility for new programs?**
If you wish to test the API to find new programs use [configdebug.txt.]( https://files.gitter.im/sphinx-dragonfly/Lobby/p2ve/configdebug.txt.) It's a global grammar which will be available on any program.

Instructions for the **development** branch. For **master** branch use `\caster\bin\data` instead of`C:\Users\%USERNAME%\.caster\data`

Instructions to use configdebug.txt on the latest version of Caster Development branch.

1. Edit or replace `configdebug.txt`  in `C:\Users\%USERNAME%\.caster\data`
3. Then say `refresh debug file` to load the debug grammar.

In the event that you find a new program let me know here. I will add it to the grammar.