### PR TITLE
Create dragonfly_dev_commands.py

### DIFF
--- a/castervoice/lib/ccr/__init__.py
+++ b/castervoice/lib/ccr/__init__.py
@@ -11,6 +11,7 @@ command_sets = {
     "cpp.cpp": ("CPP", ),
     "csharp.csharp": ("CSharp", ),
     "dart.dart": ("Dart", ),
+    "dragonfly_dev_commands.dragonfly_dev_commands": ("Dragonfly_dev_commands"),
     "go.go": ("Go", ),
     "haxe.haxe": ("Haxe", ),
     "html.html": ("HTML", ),

--- a/castervoice/lib/ccr/core/punctuation.py
+++ b/castervoice/lib/ccr/core/punctuation.py
@@ -89,22 +89,6 @@ class Punctuation(MergeRule):
         "tilde":
             R(Key("tilde"), rdescript="Tilde"),
 
-        # single parable punctuation characters with no arrow key movement afterwards (optional)
-            "lazer": R(Key("lparen"), rdescript="left parentheses"),
-            "razer": R(Key("rparen"), rdescript="right parentheses"),
-            "lapper": R(Key("lbrace"), rdescript="left curly brace"),
-            "rapper": R(Key("rbrace"), rdescript="right curly brace"),
-            "lacky": R(Key("lbracket"), rdescript="left square bracket"),
-            "racky": R(Key("rbracket"), rdescript="right square bracket"),
-            "langle": R(Key("langle"), rdescript="left angle bracket"),
-            "rangle": R(Key("rangle"), rdescript="right angle bracket"),
-            "stingle": R(Key("squote"), rdescript="single quote"),
-            "doter": R(Key("dquote"), rdescript="double quote"),
-            "backtick": R(Key("backtick"), rdescript="backtick"),
-
-
-
-
     }
 
     extras = [

--- a/castervoice/lib/ccr/core/punctuation.py
+++ b/castervoice/lib/ccr/core/punctuation.py
@@ -44,12 +44,16 @@ class Punctuation(MergeRule):
             R(Text("%(long)s" + "-" + "%(long)s"), rdescript="Dash"),
         "pipe (sim | symbol)":
             R(Text("|"), rdescript="Pipe Symbol"),
+        "long pipe (sim | symbol)":
+            R(Text(" | "), rdescript="Pipe Symbol surrounded by spaces"),
         'ace [<npunc>]':
             R(Key("space"), rdescript="Space")*Repeat(extra="npunc"),
         "clamor":
             R(Text("!"), rdescript="Exclamation Mark"),
         "deckle":
             R(Text(":"), rdescript="Colon"),
+        "long deckle":
+            R(Key("right") + Text(": ")), rdescript="move right type colon then space",
         "starling":
             R(Key("asterisk"), rdescript="Asterisk"),
         "questo":
@@ -84,6 +88,21 @@ class Punctuation(MergeRule):
             R(Key("ampersand"), rdescript="Ampersand"),
         "tilde":
             R(Key("tilde"), rdescript="Tilde"),
+
+        # single parable punctuation characters with no arrow key movement afterwards (optional)
+            "lazer": R(Key("lparen"), rdescript="left parentheses"),
+            "razer": R(Key("rparen"), rdescript="right parentheses"),
+            "lapper": R(Key("lbrace"), rdescript="left curly brace"),
+            "rapper": R(Key("rbrace"), rdescript="right curly brace"),
+            "lacky": R(Key("lbracket"), rdescript="left square bracket"),
+            "racky": R(Key("rbracket"), rdescript="right square bracket"),
+            "langle": R(Key("langle"), rdescript="left angle bracket"),
+            "rangle": R(Key("rangle"), rdescript="right angle bracket"),
+            "stingle": R(Key("squote"), rdescript="single quote"),
+            "doter": R(Key("dquote"), rdescript="double quote"),
+            "backtick": R(Key("backtick"), rdescript="backtick"),
+
+
 
 
     }

--- a/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
+++ b/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
@@ -1,7 +1,5 @@
 # this file contains commands for more quickly creating dragonfly commands.
 # users may want to make this context-specific to they're text editors
-# Dane Finley helped with this
-# inspired by Lunis Orcutt
 
 from dragonfly import (Grammar, MappingRule, Dictation, Function, Choice)
 from dragonfly.actions.action_mouse import get_cursor_position
@@ -10,6 +8,23 @@ from castervoice.lib.actions import Key, Text
 from castervoice.lib.ccr.standard import SymbolSpecs
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
+
+class PositionalTexter(object):
+
+    def __init__(self, func, extra=()):
+        self.func = func
+        self.extra = extra
+        self._str = func.__name__ 
+
+    def execute(self, data):
+        # argument = (data[self.extra[0]], data[self.extra[1]])
+        arguments = [data[argument_name] for argument_name in self.extra]
+        if not arguments:
+            return
+        result = self.func(*arguments)
+        Text(str(result)).execute()
+
+
 
 
 def split_dictation(text):
@@ -99,6 +114,7 @@ class DragonflyDevCommandsRule(MergeRule):
             rdescript="snippet for pause action"),
         "[dev] Repeat": R(Text(" * Repeat(extra='n'),"), 
             rdescript="snippet for repeat"),
+        "[dev] descript": R(Text(' rdescript=""') + Key("left"), rdescript="add the rdescript"),
         "[dev] Choice": R(Text('Choice("", {') + Key("enter:2") + Text("}),") +
             Key("up:2, right"),
                 rdescript="snippet for the choice extra"),
@@ -109,6 +125,8 @@ class DragonflyDevCommandsRule(MergeRule):
         "[dev] Mouse current [position]": R(Function(type_mouse_current),
             rdescript="snippet for making a command for clicking at the current cursor position"),
             
+
+
         # snippets for emulating recognition.
         "[dev] Mimic [<text>]": R(Function(type_mimic), rdescript="snippet for mimic"),
         "[dev] playback [<text>]": R(Function(type_playback), 
@@ -117,10 +135,11 @@ class DragonflyDevCommandsRule(MergeRule):
             rdescript="puts quotes around each word and separated by commas"),
                 
         
-        
         # for creating commands in one fell swoop
         "command [<spec>] key": R(Text('"%(spec)s": Key(""),') + Key("left:3"),
             rdescript="automatically create key command with given spec"),
+        "command [<spec>] keeper": R(Text('"%(text)s [<n>]": Key("") * Repeat(extra="n"),') + Key("left:23"),
+            rdescript="automatically create repeatable key command with given spec"),
         "command [<spec>] text": R(Text('"%(spec)s": Text(""),') + Key("left:3"),
             rdescript="automatically create text command with given spec"),
         "command [<spec>] [bring] app": R(Text('"%(spec)s": BringApp(r),') + Key("left"),
@@ -142,10 +161,15 @@ class DragonflyDevCommandsRule(MergeRule):
                 rdescript="automatically create a command to click at the current mouse position with given spec"),
             # for some reason the above command is not putting in the left click by default. perhaps someone can fix this
         
+
+
         # same as above but uses the caster standard format with the R and rdescript.
             # maybe somebody knows how to make it so that you can tab through the relevant places
         "commander [<spec>] key": R(Text('"%(spec)s": R(Key(""), rdescript=""')  + Key("right, comma") + Key("left:18"),
             rdescript="caster: automatically create key command with given spec"),
+        "commander [<spec>] keeper": R(Text('"%(spec)s [<n>]": R(Key(""), rdescript=""')  + Key("right")
+            + Text(" * Repeat(extra='n'),") + Key("left:38"),
+                rdescript="caster: automatically create repeatable key command with given spec"),
         "commander [<spec>] text": R(Text('"%(spec)s": R(Text(""), rdescript=""')  + Key("right, comma") + Key("left:18"),
             rdescript="caster: automatically create text command with given spec"),
         "commander [<spec>] [bring] app": R(Text('"%(spec)s": R(BringApp(r), rdescript=""')  + Key("right, comma") + Key("left:17"),
@@ -165,13 +189,6 @@ class DragonflyDevCommandsRule(MergeRule):
          #   + Function(type_playback) + Key("down:2") + Text(", rdescript=''") + Key("right, comma, left:3"),        
         
 
-
-
-        # Miscellaneous.
-        "plusser": Text(" + "),
-        "eaker": Text(" = "),
-        "kohler": Key("right") + Text(": "),
-        "piping": Text(" | "),   
     }
 
     extras = [

--- a/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
+++ b/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
@@ -1,0 +1,124 @@
+# this file contains commands for more quickly creating dragonfly commands.
+
+from dragonfly import (Grammar, MappingRule, Dictation, Function, Choice)
+from dragonfly.actions.action_mouse import get_cursor_position
+from castervoice.lib import control
+from castervoice.lib.actions import Key, Text
+from castervoice.lib.ccr.standard import SymbolSpecs
+from castervoice.lib.dfplus.merge.mergerule import MergeRule
+from castervoice.lib.dfplus.state.short import R
+
+def split_dictation(text):
+    if text:
+        words = ['"%s"' % word for word in text.format().split()]
+        words = ', '.join(words)
+    else:
+        words = '""'
+
+    return words
+
+
+def type_split_dictation(text):
+    Text(split_dictation(text)).execute()
+
+
+def type_mimic(text):
+    # Create an argument list for Mimic from text.
+    words = split_dictation(text)
+
+    # Define the action to execute. Move back only if no words were
+    # specified.
+    action = Text('Mimic(%s)' % words)
+    if not text:
+        action += Key("left:2")
+
+    # Execute the action.
+    action.execute()
+
+
+def type_playback(text):
+    # Create an argument list for Playback from text.
+    words = split_dictation(text)
+
+    # Define the action to execute.
+    # This will press enter a few times. Indentation will depend on your
+    # editor.
+    enter = Key("enter")
+    action = (Text('Playback([') + enter +
+              Text('([%s], 0.0),' % words) + enter +
+              Text('])') + Key("up, end"))
+
+    # Move back only if no words were specified.
+    if not text:
+        action += Key("left:9")
+
+    # Execute the action.
+    action.execute()
+
+
+def type_mouse(mouse_button):
+    action = Text('Mouse("%s")' % mouse_button)
+
+    # Move back only if no words were specified.
+    if not mouse_button:
+        action += Key("left:2")
+
+    # Execute the action.
+    action.execute()
+
+def type_mouse_current():
+    # Type Mouse("[X, Y]"). The typed Mouse action will move the cursor to
+    # back to where it was when the command was spoken.
+    Text('Mouse("[%d, %d]")' % get_cursor_position()).execute()
+
+
+class DragonflyDevCommandsRule(MergeRule):
+    mapping = {
+        # it doesn't like this pronunciation line i don't know why.
+        # pronunciation = "dragonfly dev commands"
+
+
+
+        # mimic/playback-related mappings for emulating recognition.
+        "[dev] Mimic [<text>]": Function(type_mimic),
+        "[dev] playback [<text>]": Function(type_playback),
+        "[dev] split dictation [<text>]": Function(type_split_dictation),
+    
+        # Mouse action mappings.
+        
+
+        "[dev] Mouse [<mouse_button>]": Function(type_mouse),
+        "[dev] Mouse current [position]": Function(type_mouse_current),
+
+        # Other action mappings.
+        "Key": Text('Key("")') + Key("left:2"),
+        "dev Key": Text('Key(""),') + Key("left:3"),
+        "command key [<text>]": Text('"%(text)s": Key(""),') + Key("left:3"),
+        "[dev] Text": Text('Text("")') + Key("left:2"),
+        "[dev] Pause": Text(' + Pause("")') + Key("left:2"),
+        "[dev] Repeat": Text(" * Repeat(extra='n'),"),
+        "[dev] Choice": Text('Choice("", {') + Key("enter:2") + Text("}),") +
+            Key("up:2, right"),
+        "[dev] bring app": Text("BringApp(r)") + Key("left"),
+        
+        
+    
+        # Miscellaneous.
+        "plusser": Text(" + "),
+        "eaker": Text(" = "),
+        "kohler": Key("right") + Text(": "),
+        "piping": Text(" | "),   
+    }
+
+    extras = [
+        Dictation("text"),
+        Choice("mouse_button", {
+            "left": "left",
+            "right": "right",
+            "middle": "middle",
+    }),
+    ]
+    defaults = {"text": "", "mouse_button": ""}
+
+
+control.nexus().merger.add_global_rule(DragonflyDevCommandsRule())

--- a/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
+++ b/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
@@ -1,5 +1,7 @@
 # this file contains commands for more quickly creating dragonfly commands.
 # users may want to make this context-specific to they're text editors
+# Dane Finley helped with this
+# inspired by Lunis Orcutt
 
 from dragonfly import (Grammar, MappingRule, Dictation, Function, Choice)
 from dragonfly.actions.action_mouse import get_cursor_position

--- a/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
+++ b/castervoice/lib/ccr/dragonfly_dev_commands/dragonfly_dev_commands.py
@@ -1,4 +1,5 @@
 # this file contains commands for more quickly creating dragonfly commands.
+# users may want to make this context-specific to they're text editors
 
 from dragonfly import (Grammar, MappingRule, Dictation, Function, Choice)
 from dragonfly.actions.action_mouse import get_cursor_position
@@ -7,6 +8,7 @@ from castervoice.lib.actions import Key, Text
 from castervoice.lib.ccr.standard import SymbolSpecs
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
+
 
 def split_dictation(text):
     if text:
@@ -66,11 +68,16 @@ def type_mouse(mouse_button):
     # Execute the action.
     action.execute()
 
-def type_mouse_current():
+def type_mouse_current(mouse_button):
     # Type Mouse("[X, Y]"). The typed Mouse action will move the cursor to
     # back to where it was when the command was spoken.
     Text('Mouse("[%d, %d]")' % get_cursor_position()).execute()
 
+def type_mouse_current_position_button(mouse_button = "left"):
+    first_part_of_string = 'Mouse("[%d, %d], ' % get_cursor_position()
+    second_part_of_string = '%s' % mouse_button
+    full_string = first_part_of_string + second_part_of_string
+    Text(full_string).execute()
 
 class DragonflyDevCommandsRule(MergeRule):
     mapping = {
@@ -79,30 +86,85 @@ class DragonflyDevCommandsRule(MergeRule):
 
 
 
-        # mimic/playback-related mappings for emulating recognition.
-        "[dev] Mimic [<text>]": Function(type_mimic),
-        "[dev] playback [<text>]": Function(type_playback),
-        "[dev] split dictation [<text>]": Function(type_split_dictation),
-    
-        # Mouse action mappings.
-        
-
-        "[dev] Mouse [<mouse_button>]": Function(type_mouse),
-        "[dev] Mouse current [position]": Function(type_mouse_current),
-
-        # Other action mappings.
-        "Key": Text('Key("")') + Key("left:2"),
-        "dev Key": Text('Key(""),') + Key("left:3"),
-        "command key [<text>]": Text('"%(text)s": Key(""),') + Key("left:3"),
-        "[dev] Text": Text('Text("")') + Key("left:2"),
-        "[dev] Pause": Text(' + Pause("")') + Key("left:2"),
-        "[dev] Repeat": Text(" * Repeat(extra='n'),"),
-        "[dev] Choice": Text('Choice("", {') + Key("enter:2") + Text("}),") +
+        # snippets
+        "Key": R(Text('Key("")') + Key("left:2"),  
+            rdescript="snippet for key action"),
+        "dev Key": R(Text('Key(""),') + Key("left:3"),
+            rdescript="snippet for key action"),
+        "[dev] Text": R(Text('Text("")') + Key("left:2"),
+            rdescript="snippet for text action"),
+        "[dev] Pause": R(Text(' + Pause("")') + Key("left:2"),
+            rdescript="snippet for pause action"),
+        "[dev] Repeat": R(Text(" * Repeat(extra='n'),"), 
+            rdescript="snippet for repeat"),
+        "[dev] Choice": R(Text('Choice("", {') + Key("enter:2") + Text("}),") +
             Key("up:2, right"),
-        "[dev] bring app": Text("BringApp(r)") + Key("left"),
+                rdescript="snippet for the choice extra"),
+        "[dev] bring app": R(Text("BringApp(r)") + Key("left"), 
+            rdescript="snippet for bring app"),
+        "[dev] Mouse [<mouse_button>]": R(Function(type_mouse), 
+            rdescript="snippet for mouse click command"),
+        "[dev] Mouse current [position]": R(Function(type_mouse_current),
+            rdescript="snippet for making a command for clicking at the current cursor position"),
+            
+        # snippets for emulating recognition.
+        "[dev] Mimic [<text>]": R(Function(type_mimic), rdescript="snippet for mimic"),
+        "[dev] playback [<text>]": R(Function(type_playback), 
+            rdescript="snippet for playback"), # this 1 has been inconsistent. maybe because it's automatically putting in two of each parable character e.g. brackets
+        "[dev] split dictation [<text>]": R(Function(type_split_dictation), 
+            rdescript="puts quotes around each word and separated by commas"),
+                
         
         
-    
+        # for creating commands in one fell swoop
+        "command [<spec>] key": R(Text('"%(spec)s": Key(""),') + Key("left:3"),
+            rdescript="automatically create key command with given spec"),
+        "command [<spec>] text": R(Text('"%(spec)s": Text(""),') + Key("left:3"),
+            rdescript="automatically create text command with given spec"),
+        "command [<spec>] [bring] app": R(Text('"%(spec)s": BringApp(r),') + Key("left"),
+            rdescript="automatically create bring app with given spec"),
+        "command function [<spec>]": R(Text('"%(spec)s": Function()') + Key("left"),
+            rdescript="automatically create function command with given spec"),
+        "command [<spec>] mimic [<text>]": R(Text('"%(spec)s": ,') + Key("left") 
+            + Function(type_mimic),
+                rdescript="automatically create mimic command with given spec"),
+        "command [<spec>] playback [<text>]": R(Text('"%(spec)s": ,') + Key("left") 
+            + Function(type_playback), 
+                rdescript="automatically create playback command with given spec"),
+            # the command above has been inconsistent. maybe because it's 
+            # automatically putting in two of each parable character e.g. brackets
+            # might have to adjust it depending on the editor
+        
+        "command [<spec>] mouse [<mouse_button>]": R(Text('"%(spec)s": ,') + Key("left")
+            + Function(type_mouse_current_position_button, extra={"mouse_button"}), 
+                rdescript="automatically create a command to click at the current mouse position with given spec"),
+            # for some reason the above command is not putting in the left click by default. perhaps someone can fix this
+        
+        # same as above but uses the caster standard format with the R and rdescript.
+            # maybe somebody knows how to make it so that you can tab through the relevant places
+        "commander [<spec>] key": R(Text('"%(spec)s": R(Key(""), rdescript=""')  + Key("right, comma") + Key("left:18"),
+            rdescript="caster: automatically create key command with given spec"),
+        "commander [<spec>] text": R(Text('"%(spec)s": R(Text(""), rdescript=""')  + Key("right, comma") + Key("left:18"),
+            rdescript="caster: automatically create text command with given spec"),
+        "commander [<spec>] [bring] app": R(Text('"%(spec)s": R(BringApp(r), rdescript=""')  + Key("right, comma") + Key("left:17"),
+            rdescript="caster: automatically create bing app command with given spec"),
+        "commander function [<spec>]": R(Text('"%(spec)s": R(Function(), rdescript=""')  + Key("right, comma") + Key("left:17"),
+            rdescript="caster: automatically create function command with given spec"),
+        "commander [<spec>] mimic [<text>]": R(Text('"%(spec)s": R(')
+            + Function(type_mimic) + Text(', rdescript=""')  + Key("right, comma, left:3"),
+            rdescript="caster: automatically create mimic command with given spec"),
+        "commander [<spec>] mouse [<mouse_button>]": R(Text('"%(spec)s": R(') 
+            + Function(type_mouse_current_position_button, extra={"mouse_button"})
+                + Key("right") + Text(', rdescript=""') + Key("right, comma, left:3"),
+            rdescript="caster: automatically create command to click at current mouse position with given spec"),
+        
+        # I couldn't get the one for playback to work
+        # "commander [<spec>] playback [<text>]": Text('"%(spec)s": R(') # 
+         #   + Function(type_playback) + Key("down:2") + Text(", rdescript=''") + Key("right, comma, left:3"),        
+        
+
+
+
         # Miscellaneous.
         "plusser": Text(" + "),
         "eaker": Text(" = "),
@@ -112,13 +174,16 @@ class DragonflyDevCommandsRule(MergeRule):
 
     extras = [
         Dictation("text"),
+        Dictation("dict"),
+        Dictation("spec"),
+
         Choice("mouse_button", {
             "left": "left",
             "right": "right",
             "middle": "middle",
     }),
     ]
-    defaults = {"text": "", "mouse_button": ""}
+    defaults = {"spec": "", "dict": "", "text": "", "mouse_button": ""}
 
 
 control.nexus().merger.add_global_rule(DragonflyDevCommandsRule())

--- a/castervoice26/lib27/ccr28/dragonfly_dev_commands.py
+++ b/castervoice26/lib27/ccr28/dragonfly_dev_commands.py
@@ -1,0 +1,134 @@
+"""
+    This module contains a grammar for writing Dragonfly rules.
+"""
+
+from dragonfly import (Grammar, MappingRule, Dictation, Key, Text, Function,
+                       Choice)
+from dragonfly.actions.action_mouse import get_cursor_position
+
+
+def split_dictation(text):
+    if text:
+        words = ['"%s"' % word for word in text.format().split()]
+        words = ', '.join(words)
+    else:
+        words = '""'
+
+    return words
+
+
+def type_split_dictation(text):
+    Text(split_dictation(text)).execute()
+
+
+def type_mimic(text):
+    # Create an argument list for Mimic from text.
+    words = split_dictation(text)
+
+    # Define the action to execute. Move back only if no words were
+    # specified.
+    action = Text('Mimic(%s)' % words)
+    if not text:
+        action += Key("left:2")
+
+    # Execute the action.
+    action.execute()
+
+
+def type_playback(text):
+    # Create an argument list for Playback from text.
+    words = split_dictation(text)
+
+    # Define the action to execute.
+    # This will press enter a few times. Indentation will depend on your
+    # editor.
+    enter = Key("enter")
+    action = (Text('Playback([') + enter +
+              Text('([%s], 0.0),' % words) + enter +
+              Text('])') + Key("up, end"))
+
+    # Move back only if no words were specified.
+    if not text:
+        action += Key("left:9")
+
+    # Execute the action.
+    action.execute()
+
+
+def type_mouse(mouse_button):
+    action = Text('Mouse("%s")' % mouse_button)
+
+    # Move back only if no words were specified.
+    if not mouse_button:
+        action += Key("left:2")
+
+    # Execute the action.
+    action.execute()
+
+def type_mouse_current():
+    # Type Mouse("[X, Y]"). The typed Mouse action will move the cursor to
+    # back to where it was when the command was spoken.
+    Text('Mouse("[%d, %d]")' % get_cursor_position()).execute()
+
+
+class DevRule(MappingRule):
+    mapping = {
+        mapping = {
+        # mimic/playback-related mappings for emulating recognition.
+        "[dev] Mimic [<text>]": Function(type_mimic),
+        "[dev] [<text>]": Function(type_playback),
+        "[dev] split dictation [<text>]": Function(type_split_dictation),
+    
+        # Mouse action mappings.
+        "[dev] Mouse [<mouse_button>]": Function(type_mouse),
+        "[dev] Mouse current [position]": Function(type_mouse_current),
+
+        # Other action mappings.
+        "[dev] Key": Text('Key("")') + Key("left:2"),
+        "[dev] Text": Text('Text("")') + Key("left:2"),
+        "[dev] Pause": Text(' + Pause("")') + Key("left:2"),
+        "[dev] Repeat": Text(" * Repeat(extra='n'),"),
+        "[dev] Choice": Text('Choice("", {') + Key("enter:2") + Text("}),") +
+            Key("up:2, right"),
+        "[dev] bring app": Text("BringApp(r)") + Key("left"),
+        "[dev] Pause": (Text(' + Pause("")') + Key("left:2")),
+
+
+        # Miscellaneous.
+        "plusser": Text(" + "),
+        "eaker": Text(" = "),
+        "kohler": Key("right") + Text(": "),
+        "piping": Text(" | "),
+    }
+
+    extras = [
+        Dictation("text"),
+        Choice("mouse_button", {
+            "left": "left",
+            "right": "right",
+            "middle": "middle",
+        }),
+    ]
+
+    defaults = {
+        "text": "",
+        "mouse_button": "",
+    }
+
+
+# Create a grammar instance and add DevRule to it.
+grammar = Grammar("dragonfly_dev")
+grammar.add_rule(DevRule())
+
+
+# --------------------------------------------------------------------------
+# Load the grammar instance and define how to unload it.
+grammar.load()
+
+
+# Unload function which will be called by natlink at unload time.
+def unload():
+    global grammar
+    if grammar:
+        grammar.unload()
+    grammar = None

--- a/castervoice2626/lib2727/ccr2828/dragonfly_dev_commands.py
+++ b/castervoice2626/lib2727/ccr2828/dragonfly_dev_commands.py
@@ -76,7 +76,7 @@ class DevRule(MappingRule):
         mapping = {
         # mimic/playback-related mappings for emulating recognition.
         "[dev] Mimic [<text>]": Function(type_mimic),
-        "[dev] [<text>]": Function(type_playback),
+        "dev [<text>]": Function(type_playback),
         "[dev] split dictation [<text>]": Function(type_split_dictation),
     
         # Mouse action mappings.

--- a/castervoice262626/lib272727/ccr282828/dragonfly_dev_commands.py
+++ b/castervoice262626/lib272727/ccr282828/dragonfly_dev_commands.py
@@ -76,7 +76,7 @@ class DevRule(MappingRule):
         mapping = {
         # mimic/playback-related mappings for emulating recognition.
         "[dev] Mimic [<text>]": Function(type_mimic),
-        "dev [<text>]": Function(type_playback),
+        "[dev] Playback [<text>]": Function(type_playback),
         "[dev] split dictation [<text>]": Function(type_split_dictation),
     
         # Mouse action mappings.


### PR DESCRIPTION
These are commands for creating dragonfly commands faster. Most of them should be CCR. I don't know where you want to put them. The file will require some tweaking since it was written purely for dragonfly not caster. Sorry I don't know exactly how to tweak it.
A couple of the more sophisticated commands are for making mimic and playback commands with dictation. Thanks to DaneSprite for helping a lot with this.