### PR TITLE
Implemented Typora application grammar

### DIFF
--- a/castervoice/apps/typora.py
+++ b/castervoice/apps/typora.py
@@ -1,0 +1,156 @@
+"""
+__author__ = 'LexiconCode'
+Command-module for Typora
+Official Site "https://typora.io/"
+"""
+#---------------------------------------------------------------------------
+
+from dragonfly import Dictation, Grammar, MappingRule
+
+
+from castervoice.lib import control, settings
+from castervoice.lib.actions import Key, Text
+from castervoice.lib.context import AppContext
+from castervoice.lib.dfplus.merge import gfilter
+from castervoice.lib.dfplus.merge.mergerule import MergeRule
+from castervoice.lib.dfplus.additions import IntegerRefST
+from castervoice.lib.dfplus.state.short import R
+from dragonfly import Choice, Dictation, Grammar, Pause, Repeat
+
+class TyporaRule(MergeRule):
+    pronunciation = "tie poor a"
+
+    mapping = {
+    # File
+        "new markdown":
+            R(Key("c-n"), rdescript="Typora: New Markdown Document"),
+        "new window":
+            R(Key("cs-n"), rdescript="Typora: New Window"),
+        #"new tab":
+            #R(Key(""), rdescript="Typora: New Tab"), # Not implemented in Windows OS
+        "open file":
+            R(Key("c-o"), rdescript="Typora: Open File"),
+        "open [file] quickly":
+            R(Key("c-p"), rdescript="Typora: Open Quickly"),
+        "reopen [closed] file":
+            R(Key("cs-t"), rdescript="Typora: Reopen Closed File"),
+        "save as":
+            R(Key("cs-s"), rdescript="Typora: Save As"),
+        "close file":
+            R(Key("c-w"), rdescript="Typora: Close"),
+    # Edit
+        "new paragraph":
+            R(Key("enter"), rdescript="Typora: New Paragraph")*Repeat(extra="n"),
+        "new line":
+            R(Key("s-enter"), rdescript="Typora: New Line")*Repeat(extra="n"),
+        "copy [as] markdown":
+            R(Key("cs-c"), rdescript="Typora: Copy as Markdown"),
+        "delete row":
+            R(Key("cs-backspace"), rdescript="Typora: Delete Row")*Repeat(extra="n"),
+        "select [cell | scope]":
+            R(Key("c-e"), rdescript="Typora: Select Style Scope or Cell"),
+        "select word":
+            R(Key("c-d"), rdescript="Typora: Select Word")*Repeat(extra="n"),
+        "delete word":
+            R(Key("cs-d"), rdescript="Typora: Delete Word")*Repeat(extra="n"),
+        "jump [to] top":
+            R(Key("c-home"), rdescript="Typora: Jump to Top"),
+        "jump [to] selection":
+            R(Key("c-j"), rdescript="Typora: Jump to Selection"),
+        "jump [to] buttom":
+            R(Key("c-end"), rdescript="Typora: Jump to Buttom"),
+        "find":
+            R(Key("c-f"), rdescript="Typora: Find"),
+        "find next":
+            R(Key("f3"), rdescript="Typora: Find Next"),
+        "replace":
+            R(Key("c-h"), rdescript="Typora: Replace"),
+    # Paragraph
+        "heading <n>":
+            R(Key("c-%(n)d"), rdescript="Typora: Heading 1 to 6"),
+        "paragraph":
+            R(Key("c-o"), rdescript="Typora: Paragraph"),
+        "increase heading level":
+            R(Key("c-equal"), rdescript="Typora: Increase Heading Level")*Repeat(extra="n"),
+        "decrease heading level":
+            R(Key("c-minus"), rdescript="Typora: Decrease Heading Level")*Repeat(extra="n"),
+        "table":
+            R(Key("c-t"), rdescript="Typora: Table"),
+        "code fences":
+            R(Key("cs-k"), rdescript="Typora: Code Fences"),
+        "math block":
+            R(Key("cs-m"), rdescript="Typora: Math Block"),
+        "quote":
+            R(Key("cs-q"), rdescript="Typora: Quote"),
+        "ordered list":
+            R(Key("cs-["), rdescript="Typora: Ordered List"),
+        "indent":
+            R(Key("cs-]"), rdescript="Typora: Indent")*Repeat(extra="n"),
+        "outdent":
+            R(Key("c-["), rdescript="Typora: Outdent")*Repeat(extra="n"),
+    #Format
+        "strong":
+            R(Key("c-b"), rdescript="Typora: Strong"),
+        "emphasis":
+            R(Key("c-i"), rdescript="Typora: Emphasis"),
+        "underline":
+            R(Key("c-u"), rdescript="Typora: Underline"),
+        "code":
+            R(Key("cs-`"), rdescript="Typora: Code"),
+        "strike":
+            R(Key("as-5"), rdescript="Typora: Strike"),
+        "hyperlink":
+            R(Key("c-k"), rdescript="Typora: Hyperlink"),
+        "image":
+            R(Key("cs-i"), rdescript="Typora: Image"),
+        "clear format":
+            R(Key("cs-backspace"), rdescript="Typora: Clear Format"),
+    #View
+        "toggle sidebar":
+            R(Key("cs-l"), rdescript="Typora: Toggle Sidebar"),
+        "outline":
+            R(Key("cs-1"), rdescript="Typora: Outline"),
+        "articles":
+            R(Key("sc-2"), rdescript="Typora: Articles"),
+        "file tree":
+            R(Key("cs-3"), rdescript="Typora: File Tree"),
+        "source [code] mode":
+            R(Key("c-backspace"), rdescript="Typora: Source Code Mode"),
+        "focus mode":
+            R(Key("f8"), rdescript="Typora: Focus Mode"),
+        "typewriter mode":
+            R(Key("f9"), rdescript="Typora: Typewriter Mode"),
+        "toggler fullscreen":
+            R(Key("f11"), rdescript="Typora: Toggler Fullscreen"),
+        "actual size":
+            R(Key("cs-0"), rdescript="Typora: Actual Size"),
+        "zoom in":
+            R(Key("cs-="), rdescript="Typora: Zoom In")*Repeat(extra="n"),
+        "zoom out":
+            R(Key("cs--"), rdescript="Typora: Zoom Out")*Repeat(extra="n"),
+        "switch [between opened] documnets":
+            R(Key("c-tab"), rdescript="Typora: Switch Between Opened Documnets"),
+        "toggle [dev] tools":
+            R(Key("cs-i"), rdescript="Typora: Toggle DevTools"),    
+
+    }
+    extras = [
+        Dictation("text"),
+        IntegerRefST("n", 1, 6),
+    ]
+
+
+#---------------------------------------------------------------------------
+
+context = AppContext(executable="typora")
+grammar = Grammar("typora", context=context)
+
+if settings.SETTINGS["apps"]["typora"]:
+    if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
+        control.nexus().merger.add_global_rule(TyporaRule())
+        print("added Typora")
+    else:
+        rule = TyporaRule(name="typora")
+        gfilter.run_on(rule)
+        grammar.add_rule(rule)
+        grammar.load()

--- a/castervoice/apps/typora.py
+++ b/castervoice/apps/typora.py
@@ -13,7 +13,7 @@ from castervoice.lib.dfplus.merge import gfilter
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.state.short import R
-
+# ---------------------------------------------------------------------------
 
 class TyporaRule(MergeRule):
     pronunciation = "tie poor a"
@@ -22,10 +22,9 @@ class TyporaRule(MergeRule):
         # File
         "new markdown":
             R(Key("c-n"), rdescript="Typora: New Markdown Document"),
-        "new window":
-            R(Key("cs-n"), rdescript="Typora: New Window"),
-        # "new tab":
-        # R(Key(""), rdescript="Typora: New Tab"), # Not implemented in Windows OS
+        "new window":   
+            R(Key("cs-n"), rdescript="Typora: New Window"), # Listed but not implemented
+        # "new tab":      R(Key(""), rdescript="Typora: New Tab"), # Not implemented in Windows OS
         "open file":
             R(Key("c-o"), rdescript="Typora: Open File"),
         "open [file] quickly":
@@ -38,16 +37,16 @@ class TyporaRule(MergeRule):
             R(Key("c-w"), rdescript="Typora: Close"),
         # Edit
         "new paragraph":
-            R(Key("enter"), rdescript="Typora: New Paragraph") * Repeat(extra="n"),
+            R(Key("enter"), rdescript="Typora: New Paragraph") * Repeat(extra="h"),
         "new line":
-            R(Key("s-enter"), rdescript="Typora: New Line") * Repeat(extra="n"),
+            R(Key("s-enter"), rdescript="Typora: New Line") * Repeat(extra="h"),
         "copy [as] markdown":
             R(Key("cs-c"), rdescript="Typora: Copy as Markdown"),
         "delete row":
             R(Key("cs-backspace"), rdescript="Typora: Delete Row") * Repeat(extra="n"),
         "select [cell | scope]":
             R(Key("c-e"), rdescript="Typora: Select Style Scope or Cell"),
-        "select word":
+        "[select word]":
             R(Key("c-d"), rdescript="Typora: Select Word") * Repeat(extra="n"),
         "delete word":
             R(Key("cs-d"), rdescript="Typora: Delete Word") * Repeat(extra="n"),
@@ -57,6 +56,7 @@ class TyporaRule(MergeRule):
             R(Key("c-j"), rdescript="Typora: Jump to Selection"),
         "jump [to] buttom":
             R(Key("c-end"), rdescript="Typora: Jump to Buttom"),
+        # Say "escape" to exit the find/replace context
         "find":
             R(Key("c-f"), rdescript="Typora: Find"),
         "find next":
@@ -65,15 +65,15 @@ class TyporaRule(MergeRule):
             R(Key("c-h"), rdescript="Typora: Replace"),
         # Paragraph
         "heading <n>":
-            R(Key("c-%(n)d"), rdescript="Typora: Heading 1 to 6"),
+            R(Key("c-%(h)d"), rdescript="Typora: Heading size 0 through 6"),
         "paragraph":
             R(Key("c-o"), rdescript="Typora: Paragraph"),
-        "increase heading level":
-            R(Key("c-equal"), rdescript="Typora: Increase Heading Level") * Repeat(extra="n"),
-        "decrease heading level":
-            R(Key("c-minus"), rdescript="Typora: Decrease Heading Level") * Repeat(extra="n"),
+        "increase heading [level]":
+            R(Key("c-equal"), rdescript="Typora: Increase Heading Level") * Repeat(extra="h"),
+        "decrease heading [level]":
+            R(Key("c-minus"), rdescript="Typora: Decrease Heading Level") * Repeat(extra="h"),
         "table":
-            R(Key("c-t"), rdescript="Typora: Table"),
+            R(Key("c-t"), rdescript="Typora: Table"), # could be automated.
         "code fences":
             R(Key("cs-k"), rdescript="Typora: Code Fences"),
         "math block":
@@ -83,13 +83,13 @@ class TyporaRule(MergeRule):
         "ordered list":
             R(Key("cs-["), rdescript="Typora: Ordered List"),
         "indent":
-            R(Key("cs-]"), rdescript="Typora: Indent") * Repeat(extra="n"),
+            R(Key("cs-]"), rdescript="Typora: Indent") * Repeat(extra="h"),
         "outdent":
-            R(Key("c-["), rdescript="Typora: Outdent") * Repeat(extra="n"),
+            R(Key("cs-["), rdescript="Typora: Outdent") * Repeat(extra="h"),
         # Format
-        "strong":
-            R(Key("c-b"), rdescript="Typora: Strong"),
-        "emphasis":
+        "strong | bold":
+            R(Key("c-b"), rdescript="Typora: Strong"), 
+        "emphasis | italicize":
             R(Key("c-i"), rdescript="Typora: Emphasis"),
         "underline":
             R(Key("c-u"), rdescript="Typora: Underline"),
@@ -101,10 +101,10 @@ class TyporaRule(MergeRule):
             R(Key("c-k"), rdescript="Typora: Hyperlink"),
         "image":
             R(Key("cs-i"), rdescript="Typora: Image"),
-        "clear format":
-            R(Key("cs-backspace"), rdescript="Typora: Clear Format"),
+        "clear [format]":
+            R(Key("c-\\"), rdescript="Typora: Clear Format"),
         # View
-        "toggle sidebar":
+        "[toggle] sidebar":
             R(Key("cs-l"), rdescript="Typora: Toggle Sidebar"),
         "outline":
             R(Key("cs-1"), rdescript="Typora: Outline"),
@@ -112,13 +112,13 @@ class TyporaRule(MergeRule):
             R(Key("sc-2"), rdescript="Typora: Articles"),
         "file tree":
             R(Key("cs-3"), rdescript="Typora: File Tree"),
-        "source [code] mode":
-            R(Key("c-backspace"), rdescript="Typora: Source Code Mode"),
+        "source code [mode]":
+            R(Key("c-slash"), rdescript="Typora: Source Code Mode"),
         "focus mode":
             R(Key("f8"), rdescript="Typora: Focus Mode"),
-        "typewriter mode":
+        "typewriter [mode]":
             R(Key("f9"), rdescript="Typora: Typewriter Mode"),
-        "toggler fullscreen":
+        "[toggle] fullscreen":
             R(Key("f11"), rdescript="Typora: Toggler Fullscreen"),
         "actual size":
             R(Key("cs-0"), rdescript="Typora: Actual Size"),
@@ -126,16 +126,23 @@ class TyporaRule(MergeRule):
             R(Key("cs-="), rdescript="Typora: Zoom In") * Repeat(extra="n"),
         "zoom out":
             R(Key("cs--"), rdescript="Typora: Zoom Out") * Repeat(extra="n"),
-        "switch [between opened] documnets":
+        "switch documnets":
             R(Key("c-tab"), rdescript="Typora: Switch Between Opened Documnets"),
         "toggle [dev] tools":
-            R(Key("cs-i"), rdescript="Typora: Toggle DevTools"),
+            R(Key("cs-f12"), rdescript="Typora: Toggle DevTools"),
 
     }
+    
     extras = [
         Dictation("text"),
-        IntegerRefST("n", 1, 6),
+        IntegerRefST("h", 0, 6),
+        IntegerRefST("n", 1, 30),
     ]
+
+    defaults = {
+    "n": 1,
+    "h": 1
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/castervoice/apps/typora.py
+++ b/castervoice/apps/typora.py
@@ -3,10 +3,8 @@ __author__ = 'LexiconCode'
 Command-module for Typora
 Official Site "https://typora.io/"
 """
-#---------------------------------------------------------------------------
-
-from dragonfly import Dictation, Grammar, MappingRule
-
+# ---------------------------------------------------------------------------
+from dragonfly import Dictation, Grammar, Repeat
 
 from castervoice.lib import control, settings
 from castervoice.lib.actions import Key, Text
@@ -15,19 +13,19 @@ from castervoice.lib.dfplus.merge import gfilter
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.state.short import R
-from dragonfly import Choice, Dictation, Grammar, Pause, Repeat
+
 
 class TyporaRule(MergeRule):
     pronunciation = "tie poor a"
 
     mapping = {
-    # File
+        # File
         "new markdown":
             R(Key("c-n"), rdescript="Typora: New Markdown Document"),
         "new window":
             R(Key("cs-n"), rdescript="Typora: New Window"),
-        #"new tab":
-            #R(Key(""), rdescript="Typora: New Tab"), # Not implemented in Windows OS
+        # "new tab":
+        # R(Key(""), rdescript="Typora: New Tab"), # Not implemented in Windows OS
         "open file":
             R(Key("c-o"), rdescript="Typora: Open File"),
         "open [file] quickly":
@@ -38,21 +36,21 @@ class TyporaRule(MergeRule):
             R(Key("cs-s"), rdescript="Typora: Save As"),
         "close file":
             R(Key("c-w"), rdescript="Typora: Close"),
-    # Edit
+        # Edit
         "new paragraph":
-            R(Key("enter"), rdescript="Typora: New Paragraph")*Repeat(extra="n"),
+            R(Key("enter"), rdescript="Typora: New Paragraph") * Repeat(extra="n"),
         "new line":
-            R(Key("s-enter"), rdescript="Typora: New Line")*Repeat(extra="n"),
+            R(Key("s-enter"), rdescript="Typora: New Line") * Repeat(extra="n"),
         "copy [as] markdown":
             R(Key("cs-c"), rdescript="Typora: Copy as Markdown"),
         "delete row":
-            R(Key("cs-backspace"), rdescript="Typora: Delete Row")*Repeat(extra="n"),
+            R(Key("cs-backspace"), rdescript="Typora: Delete Row") * Repeat(extra="n"),
         "select [cell | scope]":
             R(Key("c-e"), rdescript="Typora: Select Style Scope or Cell"),
         "select word":
-            R(Key("c-d"), rdescript="Typora: Select Word")*Repeat(extra="n"),
+            R(Key("c-d"), rdescript="Typora: Select Word") * Repeat(extra="n"),
         "delete word":
-            R(Key("cs-d"), rdescript="Typora: Delete Word")*Repeat(extra="n"),
+            R(Key("cs-d"), rdescript="Typora: Delete Word") * Repeat(extra="n"),
         "jump [to] top":
             R(Key("c-home"), rdescript="Typora: Jump to Top"),
         "jump [to] selection":
@@ -65,15 +63,15 @@ class TyporaRule(MergeRule):
             R(Key("f3"), rdescript="Typora: Find Next"),
         "replace":
             R(Key("c-h"), rdescript="Typora: Replace"),
-    # Paragraph
+        # Paragraph
         "heading <n>":
             R(Key("c-%(n)d"), rdescript="Typora: Heading 1 to 6"),
         "paragraph":
             R(Key("c-o"), rdescript="Typora: Paragraph"),
         "increase heading level":
-            R(Key("c-equal"), rdescript="Typora: Increase Heading Level")*Repeat(extra="n"),
+            R(Key("c-equal"), rdescript="Typora: Increase Heading Level") * Repeat(extra="n"),
         "decrease heading level":
-            R(Key("c-minus"), rdescript="Typora: Decrease Heading Level")*Repeat(extra="n"),
+            R(Key("c-minus"), rdescript="Typora: Decrease Heading Level") * Repeat(extra="n"),
         "table":
             R(Key("c-t"), rdescript="Typora: Table"),
         "code fences":
@@ -85,10 +83,10 @@ class TyporaRule(MergeRule):
         "ordered list":
             R(Key("cs-["), rdescript="Typora: Ordered List"),
         "indent":
-            R(Key("cs-]"), rdescript="Typora: Indent")*Repeat(extra="n"),
+            R(Key("cs-]"), rdescript="Typora: Indent") * Repeat(extra="n"),
         "outdent":
-            R(Key("c-["), rdescript="Typora: Outdent")*Repeat(extra="n"),
-    #Format
+            R(Key("c-["), rdescript="Typora: Outdent") * Repeat(extra="n"),
+        # Format
         "strong":
             R(Key("c-b"), rdescript="Typora: Strong"),
         "emphasis":
@@ -105,7 +103,7 @@ class TyporaRule(MergeRule):
             R(Key("cs-i"), rdescript="Typora: Image"),
         "clear format":
             R(Key("cs-backspace"), rdescript="Typora: Clear Format"),
-    #View
+        # View
         "toggle sidebar":
             R(Key("cs-l"), rdescript="Typora: Toggle Sidebar"),
         "outline":
@@ -125,13 +123,13 @@ class TyporaRule(MergeRule):
         "actual size":
             R(Key("cs-0"), rdescript="Typora: Actual Size"),
         "zoom in":
-            R(Key("cs-="), rdescript="Typora: Zoom In")*Repeat(extra="n"),
+            R(Key("cs-="), rdescript="Typora: Zoom In") * Repeat(extra="n"),
         "zoom out":
-            R(Key("cs--"), rdescript="Typora: Zoom Out")*Repeat(extra="n"),
+            R(Key("cs--"), rdescript="Typora: Zoom Out") * Repeat(extra="n"),
         "switch [between opened] documnets":
             R(Key("c-tab"), rdescript="Typora: Switch Between Opened Documnets"),
         "toggle [dev] tools":
-            R(Key("cs-i"), rdescript="Typora: Toggle DevTools"),    
+            R(Key("cs-i"), rdescript="Typora: Toggle DevTools"),
 
     }
     extras = [
@@ -140,7 +138,7 @@ class TyporaRule(MergeRule):
     ]
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 context = AppContext(executable="typora")
 grammar = Grammar("typora", context=context)

--- a/castervoice/apps/typora.py
+++ b/castervoice/apps/typora.py
@@ -15,19 +15,21 @@ from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.state.short import R
 # ---------------------------------------------------------------------------
 
+
 class TyporaRule(MergeRule):
     pronunciation = "tie poor a"
 
     mapping = {
         # File
-        "new markdown":
+        "new file":
             R(Key("c-n"), rdescript="Typora: New Markdown Document"),
-        "new window":   
-            R(Key("cs-n"), rdescript="Typora: New Window"), # Listed but not implemented
+        "new window":
+            # Listed but not implemented
+            R(Key("cs-n"), rdescript="Typora: New Window"),
         # "new tab":      R(Key(""), rdescript="Typora: New Tab"), # Not implemented in Windows OS
         "open file":
             R(Key("c-o"), rdescript="Typora: Open File"),
-        "open [file] quickly":
+        "go [to] file":
             R(Key("c-p"), rdescript="Typora: Open Quickly"),
         "reopen [closed] file":
             R(Key("cs-t"), rdescript="Typora: Reopen Closed File"),
@@ -36,44 +38,40 @@ class TyporaRule(MergeRule):
         "close file":
             R(Key("c-w"), rdescript="Typora: Close"),
         # Edit
-        "new paragraph":
-            R(Key("enter"), rdescript="Typora: New Paragraph") * Repeat(extra="h"),
-        "new line":
+        # "new paragraph": R(Key("enter"), rdescript="Typora: New Paragraph") * Repeat(extra="h"), # Caster: "shock"
+        "new line <h>":
             R(Key("s-enter"), rdescript="Typora: New Line") * Repeat(extra="h"),
         "copy [as] markdown":
             R(Key("cs-c"), rdescript="Typora: Copy as Markdown"),
-        "delete row":
+        "delete row <n>":
             R(Key("cs-backspace"), rdescript="Typora: Delete Row") * Repeat(extra="n"),
         "select [cell | scope]":
             R(Key("c-e"), rdescript="Typora: Select Style Scope or Cell"),
-        "[select word]":
+        "[select] word <n>":
             R(Key("c-d"), rdescript="Typora: Select Word") * Repeat(extra="n"),
-        "delete word":
+        "delete word <n>":
             R(Key("cs-d"), rdescript="Typora: Delete Word") * Repeat(extra="n"),
-        "jump [to] top":
-            R(Key("c-home"), rdescript="Typora: Jump to Top"),
-        "jump [to] selection":
-            R(Key("c-j"), rdescript="Typora: Jump to Selection"),
+        # "jump [to] top":    R(Key("c-home"), rdescript="Typora: Jump to Top"), # Caster: "sauce wally"
+        # "jump [to] selection":  R(Key("c-j"), rdescript="Typora: Jump to Selection"), # Caster: "dunce wally"
         "jump [to] buttom":
             R(Key("c-end"), rdescript="Typora: Jump to Buttom"),
-        # Say "escape" to exit the find/replace context
-        "find":
+        "find":  # Say "escape" to exit the find/replace context
             R(Key("c-f"), rdescript="Typora: Find"),
         "find next":
             R(Key("f3"), rdescript="Typora: Find Next"),
         "replace":
             R(Key("c-h"), rdescript="Typora: Replace"),
         # Paragraph
-        "heading <n>":
+        "heading <h>":
             R(Key("c-%(h)d"), rdescript="Typora: Heading size 0 through 6"),
         "paragraph":
             R(Key("c-o"), rdescript="Typora: Paragraph"),
-        "increase heading [level]":
+        "increase heading [level] <h>":
             R(Key("c-equal"), rdescript="Typora: Increase Heading Level") * Repeat(extra="h"),
-        "decrease heading [level]":
+        "decrease heading [level] <h>":
             R(Key("c-minus"), rdescript="Typora: Decrease Heading Level") * Repeat(extra="h"),
         "table":
-            R(Key("c-t"), rdescript="Typora: Table"), # could be automated.
+            R(Key("c-t"), rdescript="Typora: Table"),  # could be automated.
         "code fences":
             R(Key("cs-k"), rdescript="Typora: Code Fences"),
         "math block":
@@ -82,13 +80,13 @@ class TyporaRule(MergeRule):
             R(Key("cs-q"), rdescript="Typora: Quote"),
         "ordered list":
             R(Key("cs-["), rdescript="Typora: Ordered List"),
-        "indent":
+        "indent <h>":
             R(Key("cs-]"), rdescript="Typora: Indent") * Repeat(extra="h"),
-        "outdent":
+        "out dent <h>":
             R(Key("cs-["), rdescript="Typora: Outdent") * Repeat(extra="h"),
         # Format
         "strong | bold":
-            R(Key("c-b"), rdescript="Typora: Strong"), 
+            R(Key("c-b"), rdescript="Typora: Strong"),
         "emphasis | italicize":
             R(Key("c-i"), rdescript="Typora: Emphasis"),
         "underline":
@@ -122,9 +120,9 @@ class TyporaRule(MergeRule):
             R(Key("f11"), rdescript="Typora: Toggler Fullscreen"),
         "actual size":
             R(Key("cs-0"), rdescript="Typora: Actual Size"),
-        "zoom in":
+        "zoom in <n>":
             R(Key("cs-="), rdescript="Typora: Zoom In") * Repeat(extra="n"),
-        "zoom out":
+        "zoom out <n>":
             R(Key("cs--"), rdescript="Typora: Zoom Out") * Repeat(extra="n"),
         "switch documnets":
             R(Key("c-tab"), rdescript="Typora: Switch Between Opened Documnets"),
@@ -132,7 +130,7 @@ class TyporaRule(MergeRule):
             R(Key("cs-f12"), rdescript="Typora: Toggle DevTools"),
 
     }
-    
+
     extras = [
         Dictation("text"),
         IntegerRefST("h", 0, 6),
@@ -140,8 +138,8 @@ class TyporaRule(MergeRule):
     ]
 
     defaults = {
-    "n": 1,
-    "h": 1
+        "n": 1,
+        "h": 1
     }
 
 
@@ -153,7 +151,6 @@ grammar = Grammar("typora", context=context)
 if settings.SETTINGS["apps"]["typora"]:
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
         control.nexus().merger.add_global_rule(TyporaRule())
-        print("added Typora")
     else:
         rule = TyporaRule(name="typora")
         gfilter.run_on(rule)

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -202,6 +202,7 @@ _DEFAULT_SETTINGS = {
         "visualstudiocode": True,
         "winword": True,
         "wsr": True,
+        "typora": True,
     },
 
     # python settings


### PR DESCRIPTION
Put simply [Typora](https://typora.io/) gives me a seamless keyboard driven experience. It removes the preview window, mode switcher and syntax symbols of markdown source. What you see is what you get style of editor. 