### PR TITLE
Development command modification + documentation

### DIFF
--- a/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
@@ -301,6 +301,36 @@
 | `function list`      | `remove style` |
 | `preview in browser` | `stylize <n2>` |
 
+# Outlook
+
+| Command                            | Command                            | Command                             |
+|:-----------------------------------|:-----------------------------------|:------------------------------------|
+| `new (appointment / event)`        | `new contact`                      | `new folder`                        |
+| `advanced (search / find)`         | `new office document`              | `(inbox / go to inbox)`             |
+| `new journal entry`                | `new task`                         | `new contact group`                 |
+| `(new message / new mail)`         | `new note`                         | `open the new search folder window` |
+| `new meeting request`              | `new task request`                 | `to field`                          |
+| `c c field`                        | `subject [field]`                  | `subject <text>`                    |
+| `attach file`                      | `add to dictionary`                | `click send message`                |
+| `find and replace`                 | `check names`                      | `spell check`                       |
+| `save as`                          | `expand [that]`                    | `collapse [that]`                   |
+| `[go to] sent mail`                | `go to drafts`                     | `go to trash`                       |
+| `go to spam`                       | `go to starred`                    | `go to important`                   |
+| `go to outbox`                     | `sort by [<sort_by>]`              | `reverse sort`                      |
+| `block sender`                     | `search [bar] [<dict>]`            | `(message list / messages)`         |
+| `empty search [bar]`               | `refresh [mail]`                   | `open attachment`                   |
+| `[open] attachment menu`           | `next message [<n>]`               | `(prior / previous) message [<n>]`  |
+| `[select] next link`               | `[select] (previous / prior) link` | `workweek [view]`                   |
+| `full week [view]`                 | `month view`                       | `reply all`                         |
+| `forward`                          | `Mark as read`                     | `Mark as unread`                    |
+| `reply`                            | `(folder / go to folder)`          | `next pane [<n>]`                   |
+| `(un /prior /previous) pane [<n>]` | `mail view`                        | `calendar`                          |
+| `contacts`                         | `tasks`                            | `go to notes`                       |
+| `folder list`                      | `find contact`                     | `address book`                      |
+| `next open message`                | `(prior / previous) open message`  | `previous view`                     |
+| `next view`                        | `[go] back`                        | ` `                                 |
+
+
 # RStudio
 
 | Command                     | Command      | Command         |

--- a/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
@@ -8,6 +8,7 @@
 - [Dragon](#dragon)
 - [Eclipse](#eclipse)
 - [Emacs](#emacs)
+- [Excel](#excel)
 - [Internet Explorer](#internet-explorer)
 - [File Dialogues](#file-dialogues)
 - [Firefox](#firefox)
@@ -20,6 +21,7 @@
 - [Jetbrains](#jetbrains)
 - [Microsoft Visual Studio](#microsoft-visual-studio)
 - [Notepad++](#notepad)
+- [Outlook](#outlook)
 - [RStudio](#rstudio)
 - [SQL Developer](#sql-developer)
 - [SQL Server Management Studio](#sql-server-management-studio)
@@ -172,6 +174,20 @@
 | `document backward`   | `open file`           | `undo`             |
 | `document forward`    | `paragraph backward`  | `word backward`    |
 | `forward delete`      | `paragraph forward`   | `word forward`     |
+
+# Excel
+
+| Command                                                  | Command                          | Command                            |
+|:---------------------------------------------------------|:---------------------------------|:-----------------------------------|
+| `next sheet [<n>]`                                       | `(prior / previous) sheet [<n>]` | `[select] cell <column_1> <row_1>` |
+| `select <column_1> <row_1> through <column_2> <row_2>  ` | `go to cell`                     | `select current column`            |
+| `select current row`                                     | `top of column`                  | `beginning of row  `               |
+| `insert stuff`                                           | `insert row`                     | `insert column`                    |
+| `insert cell [to the] left`                              | `insert cell above  `            | `insert pivot table`               |
+| `insert pivot chart`                                     | `add-ins`                        | `add border`                       |
+| `arrange Windows`                                        | `auto sum`                       | `freeze panes`                     |
+| `toggle edit cell`                                       | ` `                              | ` `                                |
+
 
 # Internet Explorer
 

--- a/castervoice/doc/readthedocs/CCR_languages_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/CCR_languages_Quick_Reference.md
@@ -97,25 +97,28 @@ A quick reference guide for the language-specific commands included with Caster.
 | integer                   | `int`                           | while loop       | `while ()`                                                    |
 | interface                 | `interface TOKEN {}`            |                  |                                                               |
 
+# Development
+
+
 # Go
-Command | Output | | Command | Output
----|---|---|---|---
-iffae|`if  {`<br/>` }`||shells|`else {`<br/>`   }`
-switch|`switch  {`<br/>`   }`||case of|`case :`
-breaker|`break`||default|`default:`
-while loop|`for  {`<br/>`    }`||for loop|`for i := 0; i<; i++ {`<br/>`    }`
-for each|`for i := range  {`<br/>`    }`||convert to integer|`strconv.Atoi()`
-convert to string|`strconv.Itoa()`||lodge and|` && `
-lodge or|&#124; &#124;||lodge not|`!`
-print to console|`fmt.Println()`||import|`import (`<br/>`)`
-function|`func `||class|`type  struct {`<br/>`   }`
-add comment|`//`||long comment|`/**/`
-value not|`nil`||return|`return `
-value true|`true`||value false|`false`
-(inter / integer)|``||boolean|``
-string|`string`||assign|` := `
-(function / funk) main|`func main() {`<br/>`    }`||make map|`make(map[])`
-package|`package `|||``
+| Command                | Output                          |   | Command            | Output                              |
+|:-----------------------|:--------------------------------|:--|:-------------------|:------------------------------------|
+| iffae                  | `if  {`<br/>` }`                |   | shells             | `else {`<br/>`   }`                 |
+| switch                 | `switch  {`<br/>`   }`          |   | case of            | `case :`                            |
+| breaker                | `break`                         |   | default            | `default:`                          |
+| while loop             | `for  {`<br/>`    }`            |   | for loop           | `for i := 0; i<; i++ {`<br/>`    }` |
+| for each               | `for i := range  {`<br/>`    }` |   | convert to integer | `strconv.Atoi()`                    |
+| convert to string      | `strconv.Itoa()`                |   | lodge and          | ` && `                              |
+| lodge or               | &#124; &#124;                   |   | lodge not          | `!`                                 |
+| print to console       | `fmt.Println()`                 |   | import             | `import (`<br/>`)`                  |
+| function               | `func `                         |   | class              | `type  struct {`<br/>`   }`         |
+| add comment            | `//`                            |   | long comment       | `/**/`                              |
+| value not              | `nil`                           |   | return             | `return `                           |
+| value true             | `true`                          |   | value false        | `false`                             |
+| (inter / integer)      | ``                              |   | boolean            | ``                                  |
+| string                 | `string`                        |   | assign             | ` := `                              |
+| (function / funk) main | `func main() {`<br/>`    }`     |   | make map           | `make(map[])`                       |
+| package                | `package `                      |   |                    | ``                                  |
 
 # Haxe
 

--- a/castervoice/doc/readthedocs/CCR_languages_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/CCR_languages_Quick_Reference.md
@@ -5,6 +5,7 @@ A quick reference guide for the language-specific commands included with Caster.
 - [Bash](#bash)
 - [C++](#c)
 - [C&#35;](#c-1)
+- [Development](#development)
 - [Haxe](#haxe)
 - [HTML](#html)
 - [Java](#java)
@@ -98,7 +99,35 @@ A quick reference guide for the language-specific commands included with Caster.
 | interface                 | `interface TOKEN {}`            |                  |                                                               |
 
 # Development
-
+| Command                                     | Output                                                                     |
+|:--------------------------------------------|:---------------------------------------------------------------------------|
+| `dev key`                                   | `Key(""),`                                                                 |
+| `dev text`                                  | `Text("")`                                                                 |
+| `dev pause`                                 | ` + Pause("")`                                                             |
+| `dev function`                              | `Function()`                                                               |
+| `dev repeat`                                | ` * Repeat(extra='n'),`                                                    |
+| `dev choice`                                | `Choice("", {}) `                                                          |
+| `dev mouse [<mouse_button>]`                | `Mouse("left")`                                                            |
+| `dev mouse current [position]`              | `Mouse("[1003, 537]")`                                                     |
+| `dev bring app`                             | `BringApp()`                                                               |
+| `dev descript`                              | ` rdescript="MyGrammar: "`                                                 |
+| `dev mimic [<text>]`                        | `Mimic("")`                                                                |
+| `dev split dictation [<text>]`              | `"this", "is", "an", "example"`                                            |
+| `command [<spec>] key`                      | `"example": Key(""),`                                                      |
+| `command [<spec>] key repeat`               | `"example [<n>]": Key("") * Repeat(extra="n"),`                            |
+| `command [<spec>] text`                     | `"example": Text(""),`                                                     |
+| `command [<spec>] [bring] app`              | `"example": BringApp(),`                                                   |
+| `command [<spec>] function`                 | `"example": Function()`                                                    |
+| `command [<spec>] mimic [<text>]`           | `"example": Mimic("test"),`                                                |
+| `command [<spec>] playback [<text>]`        | `"example": Playback([(["test", "command"], 0.0),    ,`                    |
+| `command [<spec>] mouse [<mouse_button>]`   | `"example": Mouse("[693, 468], left,`                                      |
+| `commander [<spec>] key`                    | `"example": R(Key(""), rdescript="MyGrammar: ",`                           |
+| `commander [<spec>] key repeat`             | `"example [<n>]": R(Key(""), rdescript="MyGrammar: " * Repeat(extra='n'),` |
+| `commander [<spec>] text`                   | `"example": R(Text(""), rdescript="MyGrammar: ",`                          |
+| `commander [<spec>] [bring] app`            | `"example": R(BringApp(), rdescript="MyGrammar: ",`                        |
+| `commander [<spec>] function`               | `"example": R(Function(), rdescript="MyGrammar: ",`                        |
+| `commander [<spec>] mimic [<text>]`         | `"example": R(Mimic("test"), rdescript="MyGrammar: ",`                     |
+| `commander [<spec>] mouse [<mouse_button>]` | `"example": R(Mouse("[1244, 690], left, rdescript="" ,`                    |
 
 # Go
 | Command                | Output                          |   | Command            | Output                              |

--- a/castervoice/lib/ccr/dev_commands/dev_commands.py
+++ b/castervoice/lib/ccr/dev_commands/dev_commands.py
@@ -84,8 +84,6 @@ class DevCommands(MergeRule):
     mapping = {
 
         # Dragonfly Snippets
-        "key":
-            R(Text('Key("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Key Action"),
         "dev key":
             R(Text('Key(""),') + Key("left:3"), rdescript="DragonflyDev: Snippet for Key Action"),
         "dev text":
@@ -107,7 +105,7 @@ class DevCommands(MergeRule):
 
  # Caster Snippets
         "dev bring app":
-            R(Text("BringApp(r)") + Key("left"), rdescript="CasterDev: Snippet for Bring App"),
+            R(Text("BringApp()") + Key("left"), rdescript="CasterDev: Snippet for Bring App"),
         "dev descript":
             R(Text(' rdescript="MyGrammar: "') + Key("left"), rdescript="CasterDev: Add the rdescript"),
 
@@ -127,16 +125,16 @@ class DevCommands(MergeRule):
         "command [<spec>] key":
             R(Text('"%(spec)s": Key(""),') + Key("left:3"),
               rdescript="DragonflyDev: Automatically Create Key Command with Given Spec"),
-        "command [<spec>] keeper":
-            R(Text('"%(text)s [<n>]": Key("") * Repeat(extra="n"),') + Key("left:23"),
+        "command [<spec>] key repeat":
+            R(Text('"%(spec)s [<n>]": Key("") * Repeat(extra="n"),') + Key("left:23"),
               rdescript="DragonflyDev: Automatically Create Repeatable Key Command with Given Spec"),
         "command [<spec>] text":
             R(Text('"%(spec)s": Text(""),') + Key("left:3"),
               rdescript="DragonflyDev: Automatically Create Text Command with Given Spec"),
         "command [<spec>] [bring] app":
-            R(Text('"%(spec)s": BringApp(r),') + Key("left"),
+            R(Text('"%(spec)s": BringApp(),') + Key("left"),
               rdescript="DragonflyDev: Automatically Create Bring App with Given Spec"),
-        "command function [<spec>]":
+        "command [<spec>] function":
             R(Text('"%(spec)s": Function()') + Key("left"),
               rdescript="DragonflyDev: Automatically Create Function Command with Given Spec"),
         "command [<spec>] mimic [<text>]":
@@ -161,7 +159,7 @@ class DevCommands(MergeRule):
             R(Text('"%(spec)s": R(Key(""), rdescript="MyGrammar: "') + Key("right, comma") +
               Key("left:18"),
               rdescript="CasterDev: Automatically Create Key Command with Given Spec"),
-        "commander [<spec>] keeper":
+        "commander [<spec>] key repeat":
             R(Text('"%(spec)s [<n>]": R(Key(""), rdescript="MyGrammar: "') + Key("right") +
               Text(" * Repeat(extra='n'),") + Key("left:38"),
               rdescript="CasterDev: Automatically Create Repeatable Key Command with Given Spec"),
@@ -170,10 +168,10 @@ class DevCommands(MergeRule):
               Key("left:18"),
               rdescript="CasterDev: Automatically Create Text Command with Given Spec"),
         "commander [<spec>] [bring] app":
-            R(Text('"%(spec)s": R(BringApp(r), rdescript="MyGrammar: "') + Key("right, comma") +
+            R(Text('"%(spec)s": R(BringApp(), rdescript="MyGrammar: "') + Key("right, comma") +
               Key("left:17"),
               rdescript="CasterDev: Automatically Create Bing App Command with Given Spec"),
-        "commander function [<spec>]":
+        "commander [<spec>] function":
             R(Text('"%(spec)s": R(Function(), rdescript="MyGrammar: "') + Key("right, comma") +
               Key("left:17"),
               rdescript="CasterDev: Automatically Create Function Command with Given Spec"),

--- a/castervoice/lib/ccr/dev_commands/dev_commands.py
+++ b/castervoice/lib/ccr/dev_commands/dev_commands.py
@@ -71,23 +71,6 @@ def type_mouse_current(mouse_button):
     Text('Mouse("[%d, %d]")' % get_cursor_position()).execute()
 
 
-def move_mouse(left_right, horizontal_distance, up_down, vertical_distance):
-    # todo: make some of the arguments optional
-    new_mouse_position = list(get_cursor_position())
-    # horizontal axis
-    if left_right == "left":
-        new_mouse_position[0] -= horizontal_distance
-    if left_right == "right":
-        new_mouse_position[0] += horizontal_distance
-    # vertical axis
-    if up_down == "down":
-        new_mouse_position[1] -= vertical_distance
-    if up_down == "up":
-        new_mouse_position[1] += vertical_distance
-    new_mouse_position = tuple(new_mouse_position)
-    Mouse("[%d, %d]" % new_mouse_position).execute()
-
-
 def type_mouse_current_position_button(mouse_button="left"):
     first_part_of_string = 'Mouse("[%d, %d], ' % get_cursor_position()
     second_part_of_string = '%s' % mouse_button
@@ -96,19 +79,16 @@ def type_mouse_current_position_button(mouse_button="left"):
 
 
 class DevCommands(MergeRule):
-    pronunciation = "development" 
+    pronunciation = "development"
 
     mapping = {
-        "cursor <left_right> <distance_1> <up_down> <distance_2>":
-            R(Function(move_mouse,
-                    extra={"left_right", "distance_1", "up_down", "distance_2"})),
 
- # Dragonfly Snippets
+        # Dragonfly Snippets
         "key":
             R(Text('Key("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Key Action"),
         "dev key":
             R(Text('Key(""),') + Key("left:3"), rdescript="DragonflyDev: Snippet for Key Action"),
-        "[dev] text":
+        "dev text":
             R(Text('Text("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Text Action"),
         "dev pause":
             R(Text(' + Pause("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Pause Action"),
@@ -121,25 +101,25 @@ class DevCommands(MergeRule):
               rdescript="DragonflyDev: Snippet for the Choice Extra"),
         "dev mouse [<mouse_button>]":
             R(Function(type_mouse), rdescript="DragonflyDev: Snippet for Mouse Click Command"),
-        "[dev] mouse current [position]":
+        "dev mouse current [position]":
             R(Function(type_mouse_current),
               rdescript="DragonflyDev: Snippet for Making a Command for Clicking at the Current Cursor Position"),
 
  # Caster Snippets
-        "[dev] bring app":
+        "dev bring app":
             R(Text("BringApp(r)") + Key("left"), rdescript="CasterDev: Snippet for Bring App"),
-        "[dev] descript":
-            R(Text(' rdescript="MyGrammar: "') + Key("left"), rdescript="CasterDev: Add the rdescript"),   
+        "dev descript":
+            R(Text(' rdescript="MyGrammar: "') + Key("left"), rdescript="CasterDev: Add the rdescript"),
 
  # Snippets for emulating Dragonfly or Caster recognition.
         "dev mimic [<text>]":
-            R(Function(type_mimic), 
+            R(Function(type_mimic),
               rdescript="DragonflyDev: Snippet for Mimic"),
-        "dev playback [<text>]": # This command has been inconsistent. 
+        "dev playback [<text>]": # This command has been inconsistent.
             # maybe because it's automatically putting in two of each parable character e.g. brackets
-            R(Function(type_playback), 
+            R(Function(type_playback),
               rdescript="DragonflyDev: Snippet for Playback"),
-        "[dev] split dictation [<text>]":
+        "dev split dictation [<text>]":
             R(Function(type_split_dictation),
               rdescript="DragonflyDev: Puts Quotes Around Each Word and Separated by Commas"),
 
@@ -162,12 +142,12 @@ class DevCommands(MergeRule):
         "command [<spec>] mimic [<text>]":
             R(Text('"%(spec)s": ,') + Key("left") + Function(type_mimic),
               rdescript="DragonflyDev: Automatically Create Mimic Command with Given Spec"),
-        "command [<spec>] playback [<text>]":# This command has been inconsistent. 
+        "command [<spec>] playback [<text>]":# This command has been inconsistent.
                                              # maybe because it's automatically putting in two of each parable character e.g. bracket
                                              # might have to adjust it depending on the editor
             R(Text('"%(spec)s": ,') + Key("left") + Function(type_playback),
               rdescript="DragonflyDev: Automatically Create Playback Command with Given Spec"),
-        "command [<spec>] mouse [<mouse_button>]": # for some reason the above command is not putting in the left click by default. 
+        "command [<spec>] mouse [<mouse_button>]": # for some reason the above command is not putting in the left click by default.
                                                    # perhaps someone can fix this
             R(Text('"%(spec)s": ,') + Key("left") + Function(
                 type_mouse_current_position_button, extra={"mouse_button"}),
@@ -184,7 +164,7 @@ class DevCommands(MergeRule):
         "commander [<spec>] keeper":
             R(Text('"%(spec)s [<n>]": R(Key(""), rdescript="MyGrammar: "') + Key("right") +
               Text(" * Repeat(extra='n'),") + Key("left:38"),
-              rdescript="CasterDev: Automatically Create Repeatable Key Command with Given Spec"), 
+              rdescript="CasterDev: Automatically Create Repeatable Key Command with Given Spec"),
         "commander [<spec>] text":
             R(Text('"%(spec)s": R(Text(""), rdescript="MyGrammar: "') + Key("right, comma") +
               Key("left:18"),
@@ -202,11 +182,11 @@ class DevCommands(MergeRule):
               Key("right, comma, left:3"),
               rdescript="CasterDev: Automatically Create Mimic Command with Given Spec"),
         "commander [<spec>] mouse [<mouse_button>]":
-            R(Text('"%(spec)s": R(') + Function(type_mouse_current_position_button, 
+            R(Text('"%(spec)s": R(') + Function(type_mouse_current_position_button,
               extra={"mouse_button"}) + Key("right") + Text(', rdescript=""') + Key("right, comma, left:3"),
               rdescript="CasterDev: Automatically Create Command to Click at Current Mouse Position with Given Spec"),
         # I couldn't get "commander [<spec>] playback [<text>]" to work
-            # "commander [<spec>] playback [<text>]": Text('"%(spec)s": R(') 
+            # "commander [<spec>] playback [<text>]": Text('"%(spec)s": R(')
             #   + Function(type_playback) + Key("down:2") + Text(", rdescript=''") + Key("right, comma, left:3"),
     }
 


### PR DESCRIPTION
I've added documentation for the new Outlook, Excel and development grammars.

I've also made some modifications to the development grammar to make it a little more intuitive, and also removed the mouse movement command, which is not really related to development and is almost identical to the "curse" command in core navigation.