### PR TITLE
Create an action wrapper for read_selected_without_altering_clipboard

### DIFF
--- a/castervoice/apps/chrome.py
+++ b/castervoice/apps/chrome.py
@@ -121,7 +121,13 @@ class ChromeRule(MergeRule):
             R(Text("/msg NickServ identify PASSWORD"),
               rdescript="IRC Chat Channel Identify"),
 
-        "google that": Store() + Key("c-t") + Retrieve() + Key("enter"),
+        "google that":
+            R(Store(remove_cr=True) + Key("c-t") + Retrieve() + Key("enter"),
+                rdescript="Chrome: google that"),
+
+        "wikipedia that":
+            R(Store(space="+", remove_cr=True) + Key("c-t") + Text("https://en.wikipedia.org/w/index.php?search=") + Retrieve() + Key("enter"),
+                rdescript="Chrome: Wikipedia that"),
 
         "duplicate tab":
             R(Key("a-d,a-c,c-t/15,c-v/15, enter"), rdescript="duplicate the current tab"),

--- a/castervoice/apps/chrome.py
+++ b/castervoice/apps/chrome.py
@@ -15,6 +15,7 @@ from dragonfly import (Grammar, Context, AppContext, Dictation, Key, Text, Repea
 from castervoice.lib import control
 from castervoice.lib import settings
 from castervoice.lib.actions import Key, Text
+from castervoice.lib.temporary import Store, Retrieve
 from castervoice.lib.context import AppContext
 from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.merge import gfilter
@@ -120,8 +121,8 @@ class ChromeRule(MergeRule):
             R(Text("/msg NickServ identify PASSWORD"),
               rdescript="IRC Chat Channel Identify"),
 
-        "google that":
-            R(Key("c-c, c-t, c-v, enter"), rdescript="googles highlighted text"),
+        "google that": Store() + Key("c-t") + Retrieve() + Key("enter"),
+
         "duplicate tab":
             R(Key("a-d,a-c,c-t/15,c-v/15, enter"), rdescript="duplicate the current tab"),
         "duplicate window":

--- a/castervoice/apps/rstudio.py
+++ b/castervoice/apps/rstudio.py
@@ -63,6 +63,10 @@ class RStudioRule(MergeRule):
         R(Key("ac-f12"), rdescript="RStudio: Next Plot"),
     "previous plot":
         R(Key("ac-f11"), rdescript="RStudio: Previous Plot"),
+
+    "(help | document) that":
+        R(Store() + Key("c-2, question") + Retrieve() + Key("enter, c-3"),
+            rdescript="RStudio: Get documentation for highlighted text"),
     }
     extras = [
         IntegerRefST("n", 1, 10000),

--- a/castervoice/apps/rstudio.py
+++ b/castervoice/apps/rstudio.py
@@ -7,6 +7,7 @@ from dragonfly import (Dictation, Grammar, IntegerRef, MappingRule, Pause,
 
 from castervoice.lib import control, settings
 from castervoice.lib.actions import Key, Text
+from castervoice.lib.temporary import Store, Retrieve
 from castervoice.lib.context import AppContext
 from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.merge import gfilter
@@ -67,6 +68,11 @@ class RStudioRule(MergeRule):
     "(help | document) that":
         R(Store() + Key("c-2, question") + Retrieve() + Key("enter, c-3"),
             rdescript="RStudio: Get documentation for highlighted text"),
+    "glimpse that":
+        R(Store() + Key("c-2") + Retrieve() + Key("space, percent, rangle, percent") + Text(" glimpse()") + Key("enter/50, c-1"), rdescript="RStudio: Glimpse that"),
+    "vee table that":
+        R(Store() + Key("c-2") + Text("library(vtable)") + Key("enter/50") + Retrieve() + Key("space, percent, rangle, percent") + Text(" vtable()") + Key("enter/50, c-1"), rdescript="RStudio: Vtable that"),
+
     }
     extras = [
         IntegerRefST("n", 1, 10000),

--- a/castervoice/apps/sublime.py
+++ b/castervoice/apps/sublime.py
@@ -3,6 +3,7 @@ from dragonfly import (Choice, Dictation, Grammar, Repeat)
 from castervoice.lib import control
 from castervoice.lib import settings
 from castervoice.lib.actions import Key, Text
+from castervoice.lib.temporary import Store, Retrieve
 from castervoice.lib.context import AppContext
 from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.merge import gfilter
@@ -75,6 +76,9 @@ class SublimeRule(MergeRule):
             R(Key("c-r"), rdescript="Sublime: Go to symbol"),
         "go to [symbol in] project":
             R(Key("cs-r"), rdescript="Sublime: Go to symbol in project"),
+        "go to that":
+            Store() + Key("cs-r") + Retrieve() + Key("enter"),
+
         "command pallette":
             R(Key("cs-p"), rdescript="Sublime: Command Pallette"),
         #

--- a/castervoice/apps/sublime.py
+++ b/castervoice/apps/sublime.py
@@ -76,8 +76,13 @@ class SublimeRule(MergeRule):
             R(Key("c-r"), rdescript="Sublime: Go to symbol"),
         "go to [symbol in] project":
             R(Key("cs-r"), rdescript="Sublime: Go to symbol in project"),
+
         "go to that":
-            Store() + Key("cs-r") + Retrieve() + Key("enter"),
+            R(Store() + Key("cs-r") + Retrieve() + Key("enter"), rdescript="Sublime: Go to that"),
+        "find that in project":
+            R(Store() + Key("cs-f") + Retrieve() + Key("enter"), rdescript="Sublime: Find that in project"),
+        "find that":
+            R(Store() + Key("c-f") + Retrieve() + Key("enter"), rdescript="Sublime: Find that"),
 
         "command pallette":
             R(Key("cs-p"), rdescript="Sublime: Command Pallette"),
@@ -163,7 +168,7 @@ class SublimeRule(MergeRule):
 
 #---------------------------------------------------------------------------
 
-context = AppContext(executable="sublime_text")
+context = AppContext(executable="sublime_text", title="Sublime Text")
 grammar = Grammar("Sublime", context=context)
 
 if settings.SETTINGS["apps"]["sublime"]:

--- a/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
@@ -133,6 +133,7 @@
 | `duplicate window`                     | `extensions`                         | `(menu / three dots)`        |
 | `settings`                             | `downloads`                          | `chrome task manager`        |
 | `clear browsing data`                  | `developer tools`                    | `more tools`                 |
+| `google that`                  | `wikipedia that`                    | ``                 |
 
 ## Click by voice plug-in
 Options:
@@ -364,14 +365,15 @@ Options:
 
 # RStudio
 
-| Command                     | Command      | Command         |
-|:----------------------------|:-------------|:----------------|
-| `[go to] line <n>`          | `focus main` | `previous plot` |
-| `close tab`                 | `last tab`   | `previous tab`  |
-| `comment (line / selected)` | `new file`   | `run document`  |
-| `find`                      | `next plot`  | `run line`      |
-| `first tab`                 | `next tab`   | `save all`      |
-| `focus console`             | `open file`  | `select all`    |
+| Command                     | Command      | Command          |
+|:----------------------------|:-------------|:-----------------|
+| `[go to] line <n>`          | `focus main` | `previous plot`  |
+| `close tab`                 | `last tab`   | `previous tab`   |
+| `comment (line / selected)` | `new file`   | `run document`   |
+| `find`                      | `next plot`  | `run line`       |
+| `first tab`                 | `next tab`   | `save all`       |
+| `focus console`             | `open file`  | `select all`     |
+| `help that`                 | `head that`  | `vee table that` |
 
 # SQL Developer
 
@@ -410,7 +412,8 @@ Options:
 | `close pane`             | `next pane`                    | `previous pane`                   |
 | `pane <n2>`              | `column <one/two/left/right>`  | `focus <one/two/left/right>`      |
 | `move <n2>`              | `open terminal`                | `zoom in/out [<n2>]`              |
-| `toggle side bar`        | ``                             | ``                                |
+| `toggle side bar`        | `find that`                    | `find that in project`            |
+| `go to that`             | ` `                            | ` `                               |
 
 
 # Typora

--- a/castervoice/lib/ccr/python/python.py
+++ b/castervoice/lib/ccr/python/python.py
@@ -142,16 +142,10 @@ class Python(MergeRule):
         "meth [<unary_meth>]": R(Text("__%(unary_meth)s__(self):"),
             rdescript="Python: Unary Special Method"),
 
-        "fun <fun>":
-            Store() + Text("%(fun)s()") + Key("left") + Retrieve(action_if_text="right"),
-
     }
 
     extras = [
         Dictation("text"),
-        Choice("fun", {
-                "test": "test",
-            }),
         Choice("unary_meth", {
                 "reper": "reper",
                 "stir": "str",

--- a/castervoice/lib/ccr/python/python.py
+++ b/castervoice/lib/ccr/python/python.py
@@ -7,7 +7,6 @@ from dragonfly import Dictation, MappingRule, Choice, Pause
 
 from castervoice.lib import control
 from castervoice.lib.actions import Key, Text
-from castervoice.lib.temporary import Store, Retrieve
 from castervoice.lib.ccr.standard import SymbolSpecs
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
@@ -141,7 +140,6 @@ class Python(MergeRule):
             rdescript="Python: Binary Special Method"),
         "meth [<unary_meth>]": R(Text("__%(unary_meth)s__(self):"),
             rdescript="Python: Unary Special Method"),
-
     }
 
     extras = [

--- a/castervoice/lib/ccr/python/python.py
+++ b/castervoice/lib/ccr/python/python.py
@@ -7,6 +7,7 @@ from dragonfly import Dictation, MappingRule, Choice, Pause
 
 from castervoice.lib import control
 from castervoice.lib.actions import Key, Text
+from castervoice.lib.temporary import Store, Retrieve
 from castervoice.lib.ccr.standard import SymbolSpecs
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
@@ -106,7 +107,7 @@ class Python(MergeRule):
         "list (comprehension | comp)":
             R(Text("[x for x in TOKEN if TOKEN]"),
               rdescript="Python: List Comprehension"),
-        
+
         "[dot] (pie | pi)":
             R(Text(".py"), rdescript="Python: .py"),
         "toml":
@@ -117,18 +118,18 @@ class Python(MergeRule):
             R(Text(" is "), rdescript="Python: is"),
         "yield":
             R(Text("yield "), rdescript="Python: Yield"),
-        
+
         # Essentially an improved version of the try catch command above
-            # probably a better option than this is to use snippets with tab stops 
-            # VS code has the extension Python-snippets. these are activated by 
+            # probably a better option than this is to use snippets with tab stops
+            # VS code has the extension Python-snippets. these are activated by
             # going into the command pallet (cs-p) and typing in "insert snippet"
             # then press enter and then you have choices of snippets show up in the drop-down list.
             # you can also make your own snippets.
-        "try [<exception>]": 
-            R(Text("try : ") + Pause("10") + Key("enter/2") 
+        "try [<exception>]":
+            R(Text("try : ") + Pause("10") + Key("enter/2")
             + Text("except %(exception)s:") + Pause("10") + Key("enter/2"),
                 rdescript="create 'try catch' block with given exception"),
-        "try [<exception>] as": 
+        "try [<exception>] as":
             R(Text("try :") + Pause("10") + Key("enter/2") + Text("except %(exception)s as :")
             + Pause("10") + Key("enter/2"),  rdescript="create 'try catch as' block with given exception"),
 
@@ -136,14 +137,21 @@ class Python(MergeRule):
         "subclass": R(Text("class ():") + Key("left:3"), rdescript="Python: Subclass"),
         "dunder": R(Text("____()") + Key("left:4"),  rdescript="Python: Special Method"),
         "init": R(Text("__init__()") + Key("left"),  rdescript="Python: Init"),
-        "meth [<binary_meth>]": R(Text("__%(binary_meth)s__(self, other):"), 
-            rdescript="Python: Binary Special Method"),     
-        "meth [<unary_meth>]": R(Text("__%(unary_meth)s__(self):"), 
-            rdescript="Python: Unary Special Method"),     
+        "meth [<binary_meth>]": R(Text("__%(binary_meth)s__(self, other):"),
+            rdescript="Python: Binary Special Method"),
+        "meth [<unary_meth>]": R(Text("__%(unary_meth)s__(self):"),
+            rdescript="Python: Unary Special Method"),
+
+        "fun <fun>":
+            Store() + Text("%(fun)s()") + Key("left") + Retrieve(action_if_text="right"),
+
     }
 
     extras = [
         Dictation("text"),
+        Choice("fun", {
+                "test": "test",
+            }),
         Choice("unary_meth", {
                 "reper": "reper",
                 "stir": "str",

--- a/castervoice/lib/context.py
+++ b/castervoice/lib/context.py
@@ -68,7 +68,7 @@ def navigate_to_character(direction3, target, fill=False):
         index = _find_index_in_context(target, context, look_left)
 
         if index != -1:  # target found
-            '''move the cursor to the left of the target if looking left, 
+            '''move the cursor to the left of the target if looking left,
             to the right of the target if looking right:'''
             Key("left" if look_left else "right").execute()
             '''number of times to press left or right before the highlight

--- a/castervoice/lib/ctrl/nexus.py
+++ b/castervoice/lib/ctrl/nexus.py
@@ -17,6 +17,8 @@ class Nexus:
 
         self.clip = {}
 
+        self.temp = ""
+
         self.history = RecognitionHistoryForWSR(20)
         if not settings.WSR:
             self.history = RecognitionHistory(20)
@@ -36,12 +38,12 @@ class Nexus:
         self.macros_grammar = Grammar("recorded_macros")
 
         self.merger = CCRMerger(real_merger_config)
-        
+
         self.user_content_manager = None
-        
+
     def process_user_content(self):
         self.user_content_manager = UserContentManager()
-        
+
         self.merger.add_user_content(self.user_content_manager)
 
 

--- a/castervoice/lib/temporary.py
+++ b/castervoice/lib/temporary.py
@@ -2,6 +2,34 @@ from dragonfly import ActionBase
 from castervoice.lib import context, control
 from castervoice.lib.actions import Text, Key
 
+'''
+Stores the currently highlighted text in a temporary variable,
+to be Retrieved after some other action. If no text was
+highlighted, an empty string will be stored.
+Sample usage:
+"find that": Store() + Key("c-f") + Retrieve() + Key("enter")
+
+In order to enable use with web URLs, Store() takes a string,
+space, which will replace all space characters, and a bool,
+remove_cr, which if true will remove any newlines in the
+selection, to avoid them triggering the request early.
+Sample usage:
+"wikipedia that":
+    Store(space="+", remove_cr=True) + Key("c-t") +
+    Text("https://en.wikipedia.org/w/index.php?search=") +
+    Retrieve() + Key("enter")
+
+There are cases where you may want the same function to do
+different things depending on whether or not text was highlighted.
+The action_if_no_text and action_if_text arguments to Retrieve()
+are calls to Key() and allow this.
+For example, you may want to finish inside a set of brackets
+if no text was highlighted, but outside if there was text.
+Sample usage:
+"insert bold text":
+    Store() + Text("\\textbf{}") + Key("left") +
+    Retrieve(action_if_text="right")
+'''
 
 class Store(ActionBase):
     def __init__(self, space=" ", remove_cr=False):

--- a/castervoice/lib/temporary.py
+++ b/castervoice/lib/temporary.py
@@ -29,6 +29,11 @@ Sample usage:
 "insert bold text":
     Store() + Text("\\textbf{}") + Key("left") +
     Retrieve(action_if_text="right")
+
+NOTE:
+If the highlighted text is the same as what is currently on the
+clipboard, an empty string will be stored. This is a necessary
+side-effect of being able to detect when no text is highlighted.
 '''
 
 class Store(ActionBase):

--- a/castervoice/lib/temporary.py
+++ b/castervoice/lib/temporary.py
@@ -1,0 +1,22 @@
+from dragonfly import Function, Pause
+from castervoice.lib import context, control
+from castervoice.lib.actions import Text, Key
+
+_NEXUS = control.nexus()
+
+
+def Store():
+    def temp_store():
+        _, text = context.read_selected_without_altering_clipboard(False)
+        _NEXUS.temp = text if text else ""
+    return Function(temp_store)
+
+def Retrieve(action_if_no_text="", action_if_text=""):
+    def temp_retrieve(action_if_no_text, action_if_text):
+        Text(_NEXUS.temp).execute()
+        if _NEXUS.temp:
+            Key(action_if_text).execute()
+        else:
+            Key(action_if_no_text).execute()
+    return Function(temp_retrieve, action_if_no_text=action_if_no_text, action_if_text=action_if_text)
+


### PR DESCRIPTION
Stores the currently highlighted text in a temporary variable, to be Retrieved after some other action. If no text was highlighted, an empty string will be stored.
Sample usage:
```
"find that": Store() + Key("c-f") + Retrieve() + Key("enter")
```

In order to enable use with web URLs, Store() takes a string, space, which will replace all space characters, and a bool, remove_cr, which if true will remove any newlines in the selection, to avoid them triggering the request early.
Sample usage:
```
"wikipedia that":
    Store(space="+", remove_cr=True) + Key("c-t") +
    Text("https://en.wikipedia.org/w/index.php?search=") +
    Retrieve() + Key("enter")
```

There are cases where you may want the same function to do different things depending on whether or not text was highlighted. The action_if_no_text and action_if_text arguments to Retrieve() are calls to Key() and allow this. For example, you may want to finish inside a set of brackets if no text was highlighted, but outside if there was text.
Sample usage:
```
"insert bold text":
    Store() + Text("\\textbf{}") + Key("left") + Retrieve(action_if_text="right")
```

So far I have only implemented this in a couple of chrome and sublime commands, but there are probably quite a few situations where it would be useful to do something with highlighted text (generally searching for it somewhere or wrapping it in other text).

