### PR TITLE
Fix non-CCR for app rules

### DIFF
--- a/castervoice/doc/readthedocs/CCR.md
+++ b/castervoice/doc/readthedocs/CCR.md
@@ -85,7 +85,7 @@ This `words.txt` will create a rule filter which goes through **all** Caster rul
 MergeRule has a handful of class-level properties which can be defined to enable certain behavior.
 
 - `pronunciation`: This property allows me to change which word I can use in the `enable`/`disable` commands. For example, if my MergeRule-extending class is called `NYCCommands`, I can set `pronunciation="new york city"` in order to be able to say `enable new york city`.
-- `non`: Suppose you want a non-CCR rule activated alongside your CCR rule. For instance, let's say there are some Python commands you want available while you're coding in Python, but which you know you'll never use as part of a command sequence and which you don't want in the CCR command set for performance / phonetic distinctness reasons. You can define `non` as the class of that rule and it will be instantiated and activated alongside the MergeRule you define it on.
+- `non`: Suppose you want a non-CCR rule activated alongside your CCR rule. For instance, let's say there are some Python commands you want available while you're coding in Python, but which you know you'll never use as part of a command sequence and which you don't want in the CCR command set for performance / phonetic distinctness reasons. You can define `non` as the class of that rule and it will be instantiated and activated alongside the MergeRule you define it on. The same thing works for App CCR rules.
 
 ### How to Register Caster CCR Rules
 

--- a/castervoice/lib/dfplus/merge/ccrmerger.py
+++ b/castervoice/lib/dfplus/merge/ccrmerger.py
@@ -136,7 +136,7 @@ class CCRMerger(object):
     def add_filter(self, filter):
         if not filter in self._filters:
             self._filters.append(filter)
-            
+
     def add_user_content(self, user_content_manager):
         for rule in user_content_manager.rules:
             self.add_global_rule(rule)
@@ -239,7 +239,7 @@ class CCRMerger(object):
         if CCRMerger._ORDER not in self._config:
             self._config[CCRMerger._ORDER] = []
         enabled = [
-            r for r in self._config[CCRMerger._ORDER] 
+            r for r in self._config[CCRMerger._ORDER]
             if self._config[CCRMerger._GLOBAL].get(r)][-100:]
         self._config[CCRMerger._ORDER] = OrderedDict(izip_longest(enabled, [])).keys()
 
@@ -265,7 +265,7 @@ class CCRMerger(object):
         instantiates affiliated rules;
         adds everything to its grammar
         ;
-        assumptions made: 
+        assumptions made:
         * SelfModifyingRules have already made changes to themselves
         * the appropriate activation boolean(s) in the appropriate map has already been set'''
         current_rule = None
@@ -275,7 +275,7 @@ class CCRMerger(object):
         '''get base CCR rule'''
         if time == MergeInf.BOOT:  # rebuild via config
             for name, rule in self._global_rules.iteritems():
-                '''we want to be able to make permanent changes at boot time, not just 
+                '''we want to be able to make permanent changes at boot time, not just
                 to activated rules, but to everything -- but we dont' want it to interfere
                 with normal merge logic-- hence the introduction of the BOOT_NO_MERGE time'''
                 mp = MergePair(
@@ -318,7 +318,7 @@ class CCRMerger(object):
         for name2, rule in self._self_modifying_rules.iteritems():
             '''no need to make copies of selfmod rules because even if
             filter functions trash their mapping, they'll just regenerate
-            it next time they modify themselves; 
+            it next time they modify themselves;
             furthermore, they need to preserve state'''
             if self._config[CCRMerger._SELFMOD][name2]:
                 mp = MergePair(time, MergeInf.SELFMOD, base, rule, False)
@@ -330,12 +330,14 @@ class CCRMerger(object):
             base_copy = base.copy(
             ) if base is not None else base  # make a copy b/c commands will get stripped out
             context = rule.get_context()
+            non_copy = rule.non if rule.non else None
             mp = MergePair(time, MergeInf.APP, base_copy, rule.copy(), False,
                            CCRMerger.specs_per_rulename(self._global_rules))
             self._run_filters(mp)
             rule = self._compatibility_merge(
                 mp, base_copy, mp.rule2)  # mp.rule2 because named_rule got copied
             rule.set_context(context)
+            rule.non = non_copy
             active_apps.append(rule)
         '''negation context for appless version of base rule'''
         contexts = [app_rule.get_context() for app_rule in self._app_rules.values() \
@@ -360,6 +362,8 @@ class CCRMerger(object):
             self._add_grammar(rule)
         for rule in active_apps:
             self._add_grammar(rule, True, rule.get_context())
+            if rule.non is not None:
+                self._add_grammar(rule.non(), False, rule.get_context())
         for grammar in self._grammars:
             grammar.load()
         '''save if necessary'''


### PR DESCRIPTION
This has been bugging me for a while. 

Previously, declaring a non-CCR rule to be loaded at the same time as a CCR app rule added with `control.nexus().merger.add_app_rule` didn't work. As far as I can tell this is because the `non` property doesn't survive the `MergePair` process. Ideally it would be fixed there but I have never worked with that code so thought it better to leave it alone. This just stores the `non` before merging and restores it afterwards.