### PR TITLE
Post install enhancements with logging in new window during pip install

### DIFF
--- a/post_setup.py
+++ b/post_setup.py
@@ -1,5 +1,11 @@
 import os
 import urllib2
+import logging
+
+logging.basicConfig(format='%(message)s')
+log = logging.getLogger()
+log.addHandler(logging.FileHandler("caster-install.log", "w"))
+
 
 def finddirectory():
     try:
@@ -7,13 +13,13 @@ def finddirectory():
         status = natlinkstatus.NatlinkStatus()
         coredir = status.CoreDirectory
         directory = (os.path.dirname(coredir))
-        print("\nCaster: NatLink found.\n" "Defaulting to Dragon NaturallySpeaking Engine\n"
-              "Caster will automatically start with Dragon NaturallySpeaking\n")
+        log.warning("\nCaster: NatLink found.\n" "Defaulting to Dragon NaturallySpeaking Engine\n"
+                    "Caster will automatically start with Dragon NaturallySpeaking\n")
         return directory  # NatLink MacroSystem Directory
     except Exception:
         directory = os.path.join(os.environ['USERPROFILE'], "Desktop")
-        print("\nCaster: NatLink not found.\n" "Defaulting to Windows Speech Recognition Engine\n"
-              "Click on '_caster' on desktop to launch WSR with Caster\n")
+        log.warning("\nCaster: NatLink not found.\n" "Defaulting to Windows Speech Recognition Engine\n"
+                    "Click on '_caster' on desktop to launch WSR with Caster\n")
         return directory  # Windows User Desktop Directory
 
 
@@ -27,19 +33,24 @@ def download():
         with open(filename, 'w') as f:
             f.write(html)
     except TypeError as e:
-        print ('TypeError = ' + str(e))
+        log.warning('TypeError = ' + str(e))
     except IOError as e:
-        print ('IOError = ' + str(e))
+        log.warning('IOError = ' + str(e))
     except urllib2.HTTPError, e:
-        print ('HTTPError = ' + str(e.code))
+        log.warning('HTTPError = ' + str(e.code))
     except Exception:
         import traceback
-        print ('Generic Exception: ' + traceback.format_exc() + "\nCaster: Report Error to "
-                                                                "https://github.com/dictation-toolbox/caster/issues\n")
+        log.warning('Generic Exception: ' + traceback.format_exc() + "\nCaster: Report Error to "
+                                                                     "https://github.com/dictation-toolbox/caster/issues\n")
+def display():
+    casterlog = (os.getcwd() + "\caster-install.log")
+    command = ('type ' + casterlog)
+    os.system("start /wait cmd /k " + command)
 
 
 def main():
     download()
+    display()
     pass
 
 


### PR DESCRIPTION
This opens up a new command prompt window during install providing instructions or showing any errors in the post install script.

An effective workaround for requiring the verbose argument during PIP install.