### PR TITLE
Couple of new sublime rules

### DIFF
--- a/castervoice/apps/sublime.py
+++ b/castervoice/apps/sublime.py
@@ -1,4 +1,4 @@
-from dragonfly import (Choice, Dictation, Grammar, Repeat)
+from dragonfly import (Choice, Dictation, Grammar, Repeat, Function)
 
 from castervoice.lib import control
 from castervoice.lib import settings
@@ -10,6 +10,15 @@ from castervoice.lib.dfplus.merge import gfilter
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
 
+def action_lines(action, n, nn):
+    if nn:
+        num_lines = int(nn)-int(n)+1 if nn>n else int(n)-int(nn)+1
+        top_line = min(int(nn), int(n))
+    else:
+        num_lines = 1
+        top_line = int(n)
+    command = Key("c-g") + Text(str(top_line)) + Key("enter, s-down:" + str(num_lines) + ", " + action)
+    command.execute()
 
 class SublimeRule(MergeRule):
     pronunciation = "sublime"
@@ -68,8 +77,12 @@ class SublimeRule(MergeRule):
         #
         "line <n>":
             R(Key("c-g/10") + Text("%(n)s") + Key("enter"), rdescript="Sublime: Line n"),
+        "<action> line <n> [to <nn>]":
+            R(Function(action_lines), rdescript="Sublime: Action lines"),
         "go to file":
             R(Key("c-p"), rdescript="Sublime: Go to file"),
+        "go to <dict> [<filetype>]":
+            R(Key("c-p") + Text("%(dict)s" + "%(filetype)s") + Key("enter"), rdescript="Sublime: go to <dict> [<filetype>]"),
         "go to word":
             R(Key("c-semicolon"), rdescript="Sublime: Go to word"),
         "go to symbol":
@@ -100,6 +113,8 @@ class SublimeRule(MergeRule):
             R(Key("f11"), rdescript="Sublime: Fullscreen"),
         "toggle side bar":
             R(Key("c-k, c-b"), rdescript="Sublime: Toggle sidebar"),
+        "show key bindings":
+            Key("f10, p, right, k"),
         "zoom in [<n2>]":
             R(Key("c-equal"), rdescript="Sublime: Zoom in")*Repeat(extra="n2"),
         "zoom out [<n2>]":
@@ -124,15 +139,14 @@ class SublimeRule(MergeRule):
         "(new | create) snippet":
             R(Key("ac-n"), rdescript="Sublime: New Snippet"),
         #
-        "close pane":
-            R(Key("c-w"), rdescript="Sublime: Close Window"),
-        "next pane":
-            R(Key("c-pgdown"), rdescript="Sublime: Next Pane"),
-        "previous pane":
-            R(Key("c-pgup"), rdescript="Sublime: Previous Pane"),
-        "pane <n2>":
-            R(Key("a-%(n2)s"), rdescript="Sublime: Pane n"),
-        #
+        "close tab":
+            R(Key("c-w"), rdescript="Sublime: Close tab"),
+        "next tab":
+            R(Key("c-pgdown"), rdescript="Sublime: Next tab"),
+        "previous tab":
+            R(Key("c-pgup"), rdescript="Sublime: Previous tab"),
+        "<nth> tab":
+            R(Key("a-%(nth)s"), rdescript="Sublime: <nth> tab"),
         "column <cols>":
             R(Key("as-%(cols)s"), rdescript="Sublime: Column"),
         "focus <panel>":
@@ -142,11 +156,32 @@ class SublimeRule(MergeRule):
         #
         "open terminal":
             R(Key("cs-t"), rdescript="Sublime: Open Terminal Here"),
+
     }
     extras = [
+        Dictation("dict"),
         IntegerRefST("n", 1, 1000),
+        IntegerRefST("nn", 1, 1000),
         IntegerRefST("n2", 1, 9),
         IntegerRefST("n3", 1, 21),
+        Choice("action", {
+            "select": "",
+            "copy": "c-c",
+            "cut": "c-x",
+            "delete": "backspace",
+            "replace": "c-v",
+            }),
+        Choice("nth", {
+            "first"  : "1",
+            "second" : "2",
+            "third"  : "3",
+            "fourth" : "4",
+            "fifth"  : "5",
+            "sixth"  : "6",
+            "seventh": "7",
+            "eighth" : "8",
+            "ninth"  : "9",
+            }),
         Choice("cols", {
             "one": "1",
             "two": "2",
@@ -159,16 +194,24 @@ class SublimeRule(MergeRule):
             "two": "2",
             "right": "2",
         }),
+        Choice("filetype", {
+            "pie | python": "py",
+            "mark [down]": "md",
+            "tech": "tex",
+            "tommel": "toml",
+        }),
     ]
     defaults = {
+        "nn": None,
         "n2": 1,
         "n3": 1,
+        "filetype": "",
     }
 
 
 #---------------------------------------------------------------------------
 
-context = AppContext(executable="sublime_text", title="Sublime Text")
+context = AppContext(title="Sublime Text")
 grammar = Grammar("Sublime", context=context)
 
 if settings.SETTINGS["apps"]["sublime"]:

--- a/castervoice/apps/sublime.py
+++ b/castervoice/apps/sublime.py
@@ -30,6 +30,10 @@ class SublimeRule(MergeRule):
             R(Key("cs-n"), rdescript="Sublime: New Window"),
         "open file":
             R(Key("c-o"), rdescript="Sublime: Open File"),
+        "open folder":
+            R(Key("f10, f, down:2, enter"), rdescript="Sublime: Open Folder"),
+        "open recent":
+            R(Key("f10, f, down:3, enter"), rdescript="Sublime: Open Recent"),
         "save as":
             R(Key("cs-s"), rdescript="Sublime: Save As"),
         #
@@ -211,7 +215,7 @@ class SublimeRule(MergeRule):
 
 #---------------------------------------------------------------------------
 
-context = AppContext(title="Sublime Text")
+context = AppContext(executable="sublime_text", title="Sublime Text")
 grammar = Grammar("Sublime", context=context)
 
 if settings.SETTINGS["apps"]["sublime"]:

--- a/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
@@ -393,28 +393,29 @@ Options:
 | `close tab [<n>]`         | `prior bookmark` |                   |
 
 # Sublime
-| Command                  | Command                        | Command                           |
-|:-------------------------|:-------------------------------|:----------------------------------|
-| `new file`               | `new window`                   | `open file`                       |
-| `save as`                | `comment line`                 | `comment block`                   |
-| `outdent lines`          | `join lines`                   | `match bracket`                   |
-| `(select / sell) all`    | `(select / sell) scope [<n2>]` | `(select / sell) brackets [<n2>]` |
-| `(select / sell) indent` | `find`                         | `get all`                         |
-| `replace`                | `edit lines`                   | `edit next [<n3>]`                |
-| `edit up [<n3>]`         | `edit down [<n3>]`             | `edit all`                        |
-| `transform upper`        | `transform lower`              | `line <n>`                        |
-| `go to word`             | `go to symbol`                 | `go to [symbol in] project`       |
-| `go to file`             | `command pallette`             | `fold`                            |
-| `unfold`                 | `unfold all`                   | `fold [level] <n2>`               |
-| `full screen`            | `(set / add) bookmark`         | `next bookmark`                   |
-| `previous bookmark`      | `clear bookmarks`              | `build it`                        |
-| `record macro`           | `play [back] macro [<n3>]`     | `(new / create) snippet`          |
-| `close pane`             | `next pane`                    | `previous pane`                   |
-| `pane <n2>`              | `column <one/two/left/right>`  | `focus <one/two/left/right>`      |
-| `move <n2>`              | `open terminal`                | `zoom in/out [<n2>]`              |
-| `toggle side bar`        | `find that`                    | `find that in project`            |
-| `go to that`             | ` `                            | ` `                               |
-
+| Command                        | Command                           | Command                       |
+|:-------------------------------|:----------------------------------|:------------------------------|
+| `new file`                     | `new window`                      | `open file`                   |
+| `open folder`                  | `open recent`                     | `save as`                     |
+| `comment line`                 | `comment block`                   | `outdent lines`               |
+| `join lines`                   | `match bracket`                   | `(select / sell) all`         |
+| `(select / sell) scope [<n2>]` | `(select / sell) brackets [<n2>]` | `(select / sell) indent`      |
+| `find`                         | `get all`                         | `replace`                     |
+| `edit lines`                   | `edit next [<n3>]`                | `edit up [<n3>]`              |
+| `edit down [<n3>]`             | `edit all`                        | `transform upper`             |
+| `transform lower`              | `line <n>`                        | `<action> line <n> [to <nn>]` |
+| `go to file`                   | `go to <dict> [<filetype>]`       | `go to word`                  |
+| `go to symbol`                 | `go to [symbol in] project`       | `go to that`                  |
+| `find that in project`         | `find that`                       | `command pallette`            |
+| `fold`                         | `unfold`                          | `unfold all`                  |
+| `fold [level] <n2>`            | `full screen`                     | `toggle side bar`             |
+| `zoom in [<n2>]`               | `zoom out [<n2>]`                 | `(set / add) bookmark`        |
+| `next bookmark`                | `previous bookmark`               | `clear bookmarks`             |
+| `build it`                     | `record macro`                    | `play [back] macro [<n3>]`    |
+| `(new / create) snippet`       | `close tab`                       | `next tab`                    |
+| `previous tab`                 | `<nth> tab`                       | `column <cols>`               |
+| `focus <panel>`                | `move <panel>`                    | `open terminal`               |
+    
 
 # Typora
 | Command              | Command                        | Command                        |


### PR DESCRIPTION
Mostly minor updates and I still need to document these.

Couple of commands of interest which could easily be replicated in other editors:

* `go to <dict> [<filetype>]` - allows for example "go to sublime pie" which will take you straight to sublime.py. Doesn't work for tricky filenames but makes navigating a fair bit simpler.
* action lines - for example "copy line thirty three" or "select line five to fifteen".