### PR TITLE
Change jump specs and change behavior of "jump in lease" to be the inverse of "jump out ross"

### DIFF
--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -209,7 +209,7 @@ class Navigation(MergeRule):
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", "(~[~{~<"]))],
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back"),
         "jump back in":
-            AsynchronousAction([L(S(["cancel"], context.nav, ["left", "(~[~{~<"]))],
+            AsynchronousAction([L(S(["cancel"], context.nav, ["left", ")~]~}~>"]))],
             finisher=Key("right"), time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back In" ),
 
     # keyboard shortcuts

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -210,7 +210,7 @@ class Navigation(MergeRule):
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back"),
         "jump back in":
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", ")~]~}~>"]))],
-            finisher=Key("right"), time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back In" ),
+            time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back In" ),
 
     # keyboard shortcuts
         'save':

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -211,6 +211,12 @@ class Navigation(MergeRule):
         "jump in lease":
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", ")~]~}~>"]))],
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back In" ),
+        "butt ross":
+            AsynchronousAction([L(S(["cancel"], context.nav, ["right", ")~]~}~>"]))],
+            finisher=Key("left"), time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Out right"),
+        "butt lease":
+            AsynchronousAction([L(S(["cancel"], context.nav, ["left", "(~[~{~<"]))],
+            finisher=Key("right"), time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Out left"),
 
     # keyboard shortcuts
         'save':

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -199,16 +199,16 @@ class Navigation(MergeRule):
             R(Key("escape, escape, end"), show=False) +
             AsynchronousAction([L(S(["cancel"], Function(context.fill_within_line, nexus=_NEXUS)))],
             time_in_seconds=0.2, repetitions=50, rdescript="Core: Fill" ),
-        "jump in":
+        "jump in ross":
             AsynchronousAction([L(S(["cancel"], context.nav, ["right", "(~[~{~<"]))],
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: In"),
-        "jump out":
+        "jump out ross":
             AsynchronousAction([L(S(["cancel"], context.nav, ["right", ")~]~}~>"]))],
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Out"),
-        "jump back":
+        "jump out lease":
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", "(~[~{~<"]))],
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back"),
-        "jump back in":
+        "jump in lease":
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", ")~]~}~>"]))],
             time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back In" ),
 


### PR DESCRIPTION
I'm not sure if this is a bug or not. I was trying these commands out and found that "jump back in" had odd behavior that would go to the start of the parentheses, when I expected it to jump in once it found a closed parentheses.