### PR TITLE
Speed up Text execution

### DIFF
--- a/castervoice/lib/actions.py
+++ b/castervoice/lib/actions.py
@@ -1,6 +1,13 @@
-from dragonfly import Key, Text, Mouse
+from dragonfly import Key, Mouse
+from dragonfly import Text as TextBase
 
 from castervoice.lib import settings
+
+class Text(TextBase):
+    # dragonfly default is 0.02, too slow!
+    _pause_default = 0.003
+    def __init__(self, spec=None, static=False, pause=_pause_default, autofmt=False, use_hardware=False):
+        TextBase.__init__(self, spec=spec, static=static, pause=pause, autofmt=autofmt, use_hardware=use_hardware)
 
 # Override imported dragonfly actions with aenea's if the 'use_aenea' setting
 # is set to true.


### PR DESCRIPTION
This was discussed on the dragonfly channel. The default pause between each keystroke in a Text spec is 20ms, so for larger specs there is a noticeable lag before the execution is finished. I've dropped it to 3ms, but it could probably go lower. I've never encountered an application which had trouble with this rate of fire.