### PR TITLE
Redesign rdescripts

### DIFF
--- a/castervoice/apps/chrome.py
+++ b/castervoice/apps/chrome.py
@@ -27,130 +27,120 @@ class ChromeRule(MergeRule):
     pronunciation = "google chrome"
     mapping = {
         "new window":
-            R(Key("c-n"), rdescript="Chrome: New Window"),
+            R(Key("c-n")),
         "(new incognito window | incognito)":
-            R(Key("cs-n"), rdescript="Chrome: New Incognito Window"),
+            R(Key("cs-n")),
         "new tab [<n>]":
-            R(Key("c-t"), rdescript="Chrome: New Tab")*Repeat(extra="n"),
+            R(Key("c-t")*Repeat(extra="n")),
         "reopen tab [<n>]":
-            R(Key("cs-t"), rdescript="Chrome: Reopen Tab")*Repeat(extra="n"),
+            R(Key("cs-t"))*Repeat(extra="n"),
         "close tab [<n>]":
-            R(Key("c-w"), rdescript="Chrome: Close Tab")*Repeat(extra='n'),
+            R(Key("c-w"))*Repeat(extra='n'),
         "close all tabs":
-            R(Key("cs-w"), rdescript="Chrome: Close All Tabs"),
+            R(Key("cs-w")),
         "next tab [<n>]":
-            R(Key("c-tab"), rdescript="Chrome: Next Tab")*Repeat(extra="n"),
+            R(Key("c-tab"))*Repeat(extra="n"),
         "previous tab [<n>]":
-            R(Key("cs-tab"), rdescript="Chrome: Previous Tab")*Repeat(extra="n"),
+            R(Key("cs-tab"))*Repeat(extra="n"),
         "new tab that":
-            R(Mouse("middle") + Pause("20") + Key("c-tab"),
-              rdescript=
-              "Browser: when the mouse is hovering over a link open that link in a new tab and then go to that new tab "
-              ),
+            R(Mouse("middle") + Pause("20") + Key("c-tab")),
         "<nth> tab":
-            R(Key("c-%(nth)s"), rdescript="Chrome: nth tab" ),
+            R(Key("c-%(nth)s") ),
         "last tab":
-            R(Key("c-9"), rdescript="Chrome: Last tab"),
+            R(Key("c-9")),
         "second last tab":
-            R(Key("c-9, cs-tab"), rdescript="Chrome: Second last tab"),
+            R(Key("c-9, cs-tab")),
         "go back [<n>]":
-            R(Key("a-left/20"), rdescript="Chrome: Navigate History Backward")*
-            Repeat(extra="n"),
+            R(Key("a-left/20"))*Repeat(extra="n"),
         "go forward [<n>]":
-            R(Key("a-right/20"), rdescript="Chrome: Navigate History Forward")*
-            Repeat(extra="n"),
+            R(Key("a-right/20"))*Repeat(extra="n"),
         "zoom in [<n>]":
-            R(Key("c-plus/20"), rdescript="Chrome: Zoom In")*Repeat(extra="n"),
+            R(Key("c-plus/20"))*Repeat(extra="n"),
         "zoom out [<n>]":
-            R(Key("c-minus/20"), rdescript="Chrome: Zoom")*Repeat(extra="n"),
+            R(Key("c-minus/20"))*Repeat(extra="n"),
         "zoom reset":
-            R(Key("c-0"), rdescript="Chrome: Reset Zoom"),
+            R(Key("c-0")),
         "super refresh":
-            R(Key("c-f5"), rdescript="Chrome: Super Refresh"),
+            R(Key("c-f5")),
         "switch focus [<n>]":
-            R(Key("f6/20"), rdescript="Chrome: Switch Focus")*Repeat(extra="n"),
+            R(Key("f6/20"))*Repeat(extra="n"),
         "[find] next match [<n>]":
-            R(Key("c-g/20"), rdescript="Chrome: Next Match")*Repeat(extra="n"),
+            R(Key("c-g/20"))*Repeat(extra="n"),
         "[find] prior match [<n>]":
-            R(Key("cs-g/20"), rdescript="Chrome: Prior Match")*Repeat(extra="n"),
+            R(Key("cs-g/20"))*Repeat(extra="n"),
         "[toggle] caret browsing":
-            R(Key("f7"), rdescript="Chrome: Caret Browsing"
-              ),  # now available through an add on, was a standard feature
+            R(Key("f7")),
+              # now available through an add on, was a standard feature
         "home page":
-            R(Key("a-home"), rdescript="Chrome: Home Page"),
+            R(Key("a-home")),
         "[show] history":
-            R(Key("c-h"), rdescript="Chrome: Show History"),
+            R(Key("c-h")),
         "address bar":
-            R(Key("c-l"), rdescript="Chrome: Address Bar"),
+            R(Key("c-l")),
         "show downloads":
-            R(Key("c-j"), rdescript="Chrome: Show Downloads"),
+            R(Key("c-j")),
         "add bookmark":
-            R(Key("c-d"), rdescript="Chrome: Add Bookmark"),
+            R(Key("c-d")),
         "bookmark all tabs":
-            R(Key("cs-d"), rdescript="Chrome: Bookmark All Tabs"),
+            R(Key("cs-d")),
         "[toggle] bookmark bar":
-            R(Key("cs-b"), rdescript="Chrome: Toggle Bookmark Bar"),
+            R(Key("cs-b")),
         "[show] bookmarks":
-            R(Key("cs-o"), rdescript="Chrome: Show Bookmarks"),
+            R(Key("cs-o")),
         "switch user":
-            R(Key("cs-m"), rdescript="Chrome: Switch User"),
+            R(Key("cs-m")),
         "chrome task manager":
-            R(Key("s-escape"), rdescript="Chrome: Chrome Task Manager"),
+            R(Key("s-escape")),
         "[toggle] full-screen":
-            R(Key("f11"), rdescript="Chrome: Toggle Fullscreen Mode"),
+            R(Key("f11")),
         "focus notification":
-            R(Key("a-n"), rdescript="Chrome: Focus Notification"),
+            R(Key("a-n")),
         "allow notification":
-            R(Key("as-a"), rdescript="Chrome: Allow Notification"),
+            R(Key("as-a")),
         "deny notification":
-            R(Key("as-a"), rdescript="Chrome: Deny Notification"),
+            R(Key("as-a")),
         "developer tools":
-            R(Key("f12"), rdescript="Chrome: Developer Tools"),
+            R(Key("f12")),
         "view [page] source":
-            R(Key("c-u"), rdescript="Chrome: View Page Source"),
+            R(Key("c-u")),
         "resume":
-            R(Key("f8"), rdescript="Chrome: Resume"),
+            R(Key("f8")),
         "step over":
-            R(Key("f10"), rdescript="Chrome: Step Over"),
+            R(Key("f10")),
         "step into":
-            R(Key("f11"), rdescript="Chrome: Step Into"),
+            R(Key("f11")),
         "step out":
-            R(Key("s-f11"), rdescript="Chrome: Step Out"),
+            R(Key("s-f11")),
 
         "IRC identify":
-            R(Text("/msg NickServ identify PASSWORD"),
-              rdescript="IRC Chat Channel Identify"),
+            R(Text("/msg NickServ identify PASSWORD")),
 
         "google that":
-            R(Store(remove_cr=True) + Key("c-t") + Retrieve() + Key("enter"),
-                rdescript="Chrome: google that"),
+            R(Store(remove_cr=True) + Key("c-t") + Retrieve() + Key("enter")),
 
         "wikipedia that":
-            R(Store(space="+", remove_cr=True) + Key("c-t") + Text("https://en.wikipedia.org/w/index.php?search=") + Retrieve() + Key("enter"),
-                rdescript="Chrome: Wikipedia that"),
+            R(Store(space="+", remove_cr=True) + Key("c-t") + Text("https://en.wikipedia.org/w/index.php?search=") + Retrieve() + Key("enter")),
 
         "duplicate tab":
-            R(Key("a-d,a-c,c-t/15,c-v/15, enter"), rdescript="duplicate the current tab"),
+            R(Key("a-d,a-c,c-t/15,c-v/15, enter")),
         "duplicate window":
-            R(Key("a-d,a-c,c-n/15,c-v/15, enter"),
-              rdescript="duplicate the current tab in a new window"),
+            R(Key("a-d,a-c,c-n/15,c-v/15, enter")),
         "extensions":
-            R(Key("a-f/20, l, e/15, enter"), rdescript="chrome extensions"),
+            R(Key("a-f/20, l, e/15, enter")),
         "(menu | three dots)":
-            R(Key("a-f"),
-              rdescript="go to the three dots menu at the top right of chrome"),
+            R(Key("a-f")),
         "settings":
-            R(Key("a-f/5, s"), rdescript="chrome settings"),
+            R(Key("a-f/5, s")),
         "downloads":
-            R(Key("c-j"), rdescript="show downloads"),
+            R(Key("c-j")),
         "chrome task manager":
-            R(Key("s-escape"), rdescript="chrome task manager"),
+            R(Key("s-escape")),
         "clear browsing data":
-            R(Key("cs-del"), rdescript="clear browsing data"),
+            R(Key("cs-del")),
         "developer tools":
-            R(Key("cs-i"), rdescript="developer tools"),
+            R(Key("cs-i")),
         "more tools":
-            R(Key("a-f/5, l"), rdescript="more tools"),
+            R(Key("a-f/5, l")),
 
         # click by voice chrome extension commands
         # these require the click by voice Chrome extension
@@ -158,26 +148,20 @@ class ChromeRule(MergeRule):
         #  (I haven't tried surfer keys yet, but apparently that's another good option)
         "<numbers> <dictation>":
             R(Key("cs-space/30") + Text("%(numbers)d:%(click_by_voice_options)s") +
-              Key("enter/30") + Text("%(dictation)s"),
-              rdescript="input dictation into numbered text field"),
+              Key("enter/30") + Text("%(dictation)s")),
         "go <numbers> <dictation>":
             R(Key("cs-space/30") + Text("%(numbers)d:%(click_by_voice_options)s") +
-              Key("enter/30") + Text("%(dictation)s") + Key("enter"),
-              rdescript="input dictation into numbered text field then press enter"),
+              Key("enter/30") + Text("%(dictation)s") + Key("enter")),
         "next <numbers> <dictation>":
             R(Key("cs-space/30") + Text("%(numbers)d:%(click_by_voice_options)s") +
-              Key("enter/30") + Text("%(dictation)s") + Key("tab"),
-              rdescript="input dictation into numbered text field then press tab"),
+              Key("enter/30") + Text("%(dictation)s") + Key("tab")),
         "<numbers> [<click_by_voice_options>]":
             R(Key("cs-space/30") + Text("%(numbers)d:%(click_by_voice_options)s") +
-              Key("enter"),
-              rdescript="click link with click by voice options"),
+              Key("enter")),
         "hide hints":
-            R(Key("cs-space/30") + Text(":-") + Key("enter"),
-              rdescript="hide click by voice hints (i.e. numbers)"),
+            R(Key("cs-space/30") + Text(":-") + Key("enter")),
         "show hints":
-            R(Key("cs-space/30") + Text(":+") + Key("enter"),
-              rdescript="show click by voice hints (i.e. numbers)"),
+            R(Key("cs-space/30") + Text(":+") + Key("enter")),
     }
     extras = [
         Choice(

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -28,125 +28,112 @@ class NavigationNon(MergeRule):
                 repetitions=1000,
                 blocking=False),
         "erase multi clipboard":
-            R(Function(navigation.erase_multi_clipboard, nexus=_NEXUS),
-              rdescript="Core: Erase Multi Clipboard"),
+            R(Function(navigation.erase_multi_clipboard, nexus=_NEXUS)),
         "find":
-            R(Key("c-f"), rdescript="Core: Find"),
+            R(Key("c-f")),
         "find next [<n>]":
-            R(Key("f3"), rdescript="Core: Find Next")*Repeat(extra="n"),
+            R(Key("f3"))*Repeat(extra="n"),
         "find prior [<n>]":
-            R(Key("s-f3"), rdescript="Core: Find Prior")*Repeat(extra="n"),
+            R(Key("s-f3"))*Repeat(extra="n"),
         "find everywhere":
-            R(Key("cs-f"), rdescript="Core: Find Everywhere"),
+            R(Key("cs-f")),
         "replace":
-            R(Key("c-h"), rdescript="Core: Replace"),
+            R(Key("c-h")),
         "(F to | F2)":
-            R(Key("f2"), rdescript="Core: Key: F2"),
+            R(Key("f2")),
         "(F six | F6)":
-            R(Key("f6"), rdescript="Core: Key: F6"),
+            R(Key("f6")),
         "(F nine | F9)":
-            R(Key("f9"), rdescript="Core: Key: F9"),
+            R(Key("f9")),
         "[show] context menu":
-            R(Key("s-f10"), rdescript="Core: Context Menu"),
+            R(Key("s-f10")),
         "squat":
-            R(Function(navigation.left_down, nexus=_NEXUS), rdescript="Core-Mouse: Left Down"),
+            R(Function(navigation.left_down, nexus=_NEXUS)),
         "bench":
-            R(Function(navigation.left_up, nexus=_NEXUS), rdescript="Core-Mouse: Left Up"),
+            R(Function(navigation.left_up, nexus=_NEXUS)),
         "kick":
-            R(Function(navigation.left_click, nexus=_NEXUS),
-              rdescript="Core-Mouse: Left Click"),
+            R(Function(navigation.left_click, nexus=_NEXUS)),
         "kick mid":
-            R(Function(navigation.middle_click, nexus=_NEXUS),
-              rdescript="Core-Mouse: Middle Click"),
+            R(Function(navigation.middle_click, nexus=_NEXUS)),
         "psychic":
-            R(Function(navigation.right_click, nexus=_NEXUS),
-              rdescript="Core-Mouse: Right Click"),
+            R(Function(navigation.right_click, nexus=_NEXUS)),
         "(kick double|double kick)":
-            R(Function(navigation.left_click, nexus=_NEXUS)*Repeat(2),
-              rdescript="Core-Mouse: Double Click"),
+            R(Function(navigation.left_click, nexus=_NEXUS)*Repeat(2)),
         "shift right click":
-            R(Key("shift:down") + Mouse("right") + Key("shift:up"),
-              rdescript="Core-Mouse: Shift + Right Click"),
+            R(Key("shift:down") + Mouse("right") + Key("shift:up")),
         "curse <direction> [<direction2>] [<nnavi500>] [<dokick>]":
-            R(Function(navigation.curse), rdescript="Core: Curse"),
+            R(Function(navigation.curse)),
         "scree <direction> [<nnavi500>]":
-            R(Function(navigation.wheel_scroll), rdescript="Core: Wheel Scroll"),
+            R(Function(navigation.wheel_scroll)),
         "colic":
-            R(Key("control:down") + Mouse("left") + Key("control:up"),
-              rdescript="Core-Mouse: Ctrl + Left Click"),
+            R(Key("control:down") + Mouse("left") + Key("control:up")),
         "garb [<nnavi500>]":
             R(Mouse("left") + Mouse("left") + Function(
                 navigation.stoosh_keep_clipboard,
-                nexus=_NEXUS),
-              rdescript="Core: Highlight @ Mouse + Copy"),
+                nexus=_NEXUS)),
         "drop [<nnavi500>]":
             R(Mouse("left") + Mouse("left") + Function(
                 navigation.drop_keep_clipboard,
                 nexus=_NEXUS,
                 capitalization=0,
-                spacing=0),
-              rdescript="Core: Highlight @ Mouse + Paste"),
+                spacing=0)),
         "sure stoosh":
-            R(Key("c-c"), rdescript="Core: Simple Copy"),
+            R(Key("c-c")),
         "sure cut":
-            R(Key("c-x"), rdescript="Core: Simple Cut"),
+            R(Key("c-x")),
         "sure spark":
-            R(Key("c-v"), rdescript="Core: Simple Paste"),
+            R(Key("c-v")),
         "undo [<n>]":
-            R(Key("c-z"), rdescript="Core: Undo")*Repeat(extra="n"),
+            R(Key("c-z"))*Repeat(extra="n"),
         "redo [<n>]":
-            R(Key("c-y"), rdescript="Core: Redo")*Repeat(extra="n"),
+            R(Key("c-y"))*Repeat(extra="n"),
         "refresh":
-            R(Key("c-r"), rdescript="Core: Refresh"),
+            R(Key("c-r")),
         "maxiwin":
-            R(Key("w-up"), rdescript="Core: Maximize Window"),
+            R(Key("w-up")),
         "move window":
-            R(Key("a-space, r, a-space, m"), rdescript="Core: Move Window"),
+            R(Key("a-space, r, a-space, m")),
         "window (left | lease) [<n>]":
-            R(Key("w-left"), rdescript="Core: Window Left")*Repeat(extra="n"),
+            R(Key("w-left"))*Repeat(extra="n"),
         "window (right | ross) [<n>]":
-            R(Key("w-right"), rdescript="Core: Window Right")*Repeat(extra="n"),
+            R(Key("w-right"))*Repeat(extra="n"),
         "monitor (left | lease) [<n>]":
-            R(Key("sw-left"), rdescript="Core: Monitor Left")*Repeat(extra="n"),
+            R(Key("sw-left"))*Repeat(extra="n"),
         "monitor (right | ross) [<n>]":
-            R(Key("sw-right"), rdescript="Core: Monitor Right")*Repeat(extra="n"),
+            R(Key("sw-right"))*Repeat(extra="n"),
         "(next | prior) window":
-            R(Key("ca-tab, enter"), rdescript="Core: Next Window"),
+            R(Key("ca-tab, enter")),
         "switch (window | windows)":
-            R(Key("ca-tab"), rdescript="Core: Switch Window")*Repeat(extra="n"),
+            R(Key("ca-tab"))*Repeat(extra="n"),
         "next tab [<n>]":
             R(Key("c-pgdown"))*Repeat(extra="n"),
         "prior tab [<n>]":
-            R(Key("c-pgup"), rdescript="Core: Previous Tab")*Repeat(extra="n"),
+            R(Key("c-pgup"))*Repeat(extra="n"),
         "close tab [<n>]":
-            R(Key("c-w/20"), rdescript="Core: Close Tab")*Repeat(extra="n"),
+            R(Key("c-w/20"))*Repeat(extra="n"),
         "elite translation <text>":
-            R(Function(alphanumeric.elite_text), rdescript="Core: 1337 Text"),
+            R(Function(alphanumeric.elite_text)),
 
         # Workspace management
         "show work [spaces]":
-            R(Key("w-tab"), rdescript="Core: Show Workspaces"),
+            R(Key("w-tab")),
         "(create | new) work [space]":
-            R(Key("wc-d"), rdescript="Core: Create Workspace"),
+            R(Key("wc-d")),
         "close work [space]":
-            R(Key("wc-f4"), rdescript="Core: Close Workspace"),
+            R(Key("wc-f4")),
         "close all work [spaces]":
-            R(Function(utilities.close_all_workspaces),
-                rdescript="Core: Close All Work Spaces"),
+            R(Function(utilities.close_all_workspaces)),
         "next work [space] [<n>]":
-            R(Key("wc-right"), rdescript="Core: Next Workspace")*Repeat(extra="n"),
+            R(Key("wc-right"))*Repeat(extra="n"),
         "(previous | prior) work [space] [<n>]":
-            R(Key("wc-left"), rdescript="Core: Prior Workspace")*Repeat(extra="n"),
+            R(Key("wc-left"))*Repeat(extra="n"),
 
         "go work [space] <n>":
-            R(Function(lambda n: utilities.go_to_desktop_number(n)),
-                rdescript="Core: Go to Workspace N"),
+            R(Function(lambda n: utilities.go_to_desktop_number(n))),
         "send work [space] <n>":
-            R(Function(lambda n: utilities.move_current_window_to_desktop(n)),
-                rdescript="Core: Send Current Window to Workspace N"),
+            R(Function(lambda n: utilities.move_current_window_to_desktop(n))),
         "move work [space] <n>":
-            R(Function(lambda n: utilities.move_current_window_to_desktop(n, True)),
-                rdescript="Core: Move Current Window to Workspace N"),
+            R(Function(lambda n: utilities.move_current_window_to_desktop(n, True))),
     }
 
     extras = [
@@ -198,77 +185,76 @@ class Navigation(MergeRule):
         "fill <target>":
             R(Key("escape, escape, end"), show=False) +
             AsynchronousAction([L(S(["cancel"], Function(context.fill_within_line, nexus=_NEXUS)))],
-            time_in_seconds=0.2, repetitions=50, rdescript="Core: Fill" ),
+            time_in_seconds=0.2, repetitions=50 ),
         "jump in":
             AsynchronousAction([L(S(["cancel"], context.nav, ["right", "(~[~{~<"]))],
-            time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: In"),
+            time_in_seconds=0.1, repetitions=50),
         "jump out":
             AsynchronousAction([L(S(["cancel"], context.nav, ["right", ")~]~}~>"]))],
-            time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Out"),
+            time_in_seconds=0.1, repetitions=50),
         "jump back":
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", "(~[~{~<"]))],
-            time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back"),
+            time_in_seconds=0.1, repetitions=50),
         "jump back in":
             AsynchronousAction([L(S(["cancel"], context.nav, ["left", "(~[~{~<"]))],
-            finisher=Key("right"), time_in_seconds=0.1, repetitions=50, rdescript="Core: Jump: Back In" ),
+            finisher=Key("right"), time_in_seconds=0.1, repetitions=50 ),
 
     # keyboard shortcuts
         'save':
-            R(Key("c-s"), rspec="save", rdescript="Core: Save"),
+            R(Key("c-s"), rspec="save"),
         'shock [<nnavi50>]':
-            R(Key("enter"), rspec="shock", rdescript="Core: Enter")* Repeat(extra="nnavi50"),
+            R(Key("enter"), rspec="shock")* Repeat(extra="nnavi50"),
 
         "(<mtn_dir> | <mtn_mode> [<mtn_dir>]) [(<nnavi500> | <extreme>)]":
-            R(Function(text_utils.master_text_nav), rdescript="Core: Keyboard Text Navigation"),
+            R(Function(text_utils.master_text_nav)),
 
         "shift click":
-            R(Key("shift:down") + Mouse("left") + Key("shift:up"),
-              rdescript="Core-Mouse: Shift Click"),
+            R(Key("shift:down") + Mouse("left") + Key("shift:up")),
 
         "stoosh [<nnavi500>]":
-            R(Function(navigation.stoosh_keep_clipboard, nexus=_NEXUS), rspec="stoosh", rdescript="Core: Copy"),
+            R(Function(navigation.stoosh_keep_clipboard, nexus=_NEXUS), rspec="stoosh"),
         "cut [<nnavi500>]":
-            R(Function(navigation.cut_keep_clipboard, nexus=_NEXUS), rspec="cut", rdescript="Core: Cut"),
+            R(Function(navigation.cut_keep_clipboard, nexus=_NEXUS), rspec="cut"),
         "spark [<nnavi500>] [(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)]":
-            R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark", rdescript="Core: Paste"),
+            R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark"),
 
         "splat [<splatdir>] [<nnavi10>]":
-            R(Key("c-%(splatdir)s"), rspec="splat", rdescript="Core: Splat") * Repeat(extra="nnavi10"),
+            R(Key("c-%(splatdir)s"), rspec="splat") * Repeat(extra="nnavi10"),
         "deli [<nnavi50>]":
-            R(Key("del/5"), rspec="deli", rdescript="Core: Delete") * Repeat(extra="nnavi50"),
+            R(Key("del/5"), rspec="deli") * Repeat(extra="nnavi50"),
         "clear [<nnavi50>]":
-            R(Key("backspace/5:%(nnavi50)d"), rspec="clear", rdescript="Core: Backspace"),
+            R(Key("backspace/5:%(nnavi50)d"), rspec="clear"),
         SymbolSpecs.CANCEL:
-            R(Key("escape"), rspec="cancel", rdescript="Core: Cancel Action"),
+            R(Key("escape"), rspec="cancel"),
 
 
         "shackle":
-            R(Key("home/5, s-end"), rspec="shackle", rdescript="Core: Select Line"),
+            R(Key("home/5, s-end"), rspec="shackle"),
         "(tell | tau) <semi>":
-            R(Function(navigation.next_line), rspec="tell dock", rdescript="Core: Complete Line"),
+            R(Function(navigation.next_line), rspec="tell dock"),
         "duple [<nnavi50>]":
-            R(Function(navigation.duple_keep_clipboard), rspec="duple", rdescript="Core: Duplicate Line"),
+            R(Function(navigation.duple_keep_clipboard), rspec="duple"),
         "Kraken":
-            R(Key("c-space"), rspec="Kraken", rdescript="Core: Control Space"),
+            R(Key("c-space"), rspec="Kraken"),
 
     # text formatting
         "set [<big>] format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":
-            R(Function(textformat.set_text_format), rdescript="Core: Set Text Format"),
+            R(Function(textformat.set_text_format)),
         "clear castervoice [<big>] formatting":
-            R(Function(textformat.clear_text_format), rdescript="Core: Clear Caster Formatting"),
+            R(Function(textformat.clear_text_format)),
         "peek [<big>] format":
-            R(Function(textformat.peek_text_format), rdescript="Core: Peek Format"),
+            R(Function(textformat.peek_text_format)),
         "(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel) <textnv> [brunt]":
-            R(Function(textformat.master_format_text), rdescript="Core: Text Format"),
+            R(Function(textformat.master_format_text)),
         "[<big>] format <textnv>":
-            R(Function(textformat.prior_text_format), rdescript="Core: Last Text Format"),
+            R(Function(textformat.prior_text_format)),
         "<word_limit> [<big>] format <textnv>":
-            R(Function(textformat.partial_format_text), rdescript="Core: Partial Text Format"),
+            R(Function(textformat.partial_format_text)),
 
         "hug <enclosure>":
-            R(Function(text_utils.enclose_selected), rdescript="Core: Enclose text "),
+            R(Function(text_utils.enclose_selected)),
         "dredge":
-            R(Key("a-tab"), rdescript="Core: Alt-Tab"),
+            R(Key("a-tab")),
 
     }
 

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -20,7 +20,7 @@ from castervoice.lib.ccr.standard import SymbolSpecs
 _NEXUS = control.nexus()
 
 
-class NavigationNon(MappingRule):
+class NavigationNon(MergeRule):
     mapping = {
         "<direction> <time_in_seconds>":
             AsynchronousAction(
@@ -115,7 +115,7 @@ class NavigationNon(MappingRule):
         "switch (window | windows)":
             R(Key("ca-tab"), rdescript="Core: Switch Window")*Repeat(extra="n"),
         "next tab [<n>]":
-            R(Key("c-pgdown"), rdescript="Core: Next Tab")*Repeat(extra="n"),
+            R(Key("c-pgdown"))*Repeat(extra="n"),
         "prior tab [<n>]":
             R(Key("c-pgup"), rdescript="Core: Previous Tab")*Repeat(extra="n"),
         "close tab [<n>]":

--- a/castervoice/lib/ccr/python/python.py
+++ b/castervoice/lib/ccr/python/python.py
@@ -15,15 +15,14 @@ from castervoice.lib.dfplus.state.short import R
 class PythonNon(MappingRule):
     mapping = {
         "with":
-            R(Text("with "), rdescript="Python: With"),
+            R(Text("with ")),
         "open file":
-            R(Text("open('filename','r') as f:"), rdescript="Python: Open File"),
+            R(Text("open('filename','r') as f:")),
         "read lines":
-            R(Text("content = f.readlines()"), rdescript="Python: Read Lines"),
+            R(Text("content = f.readlines()")),
         "try catch":
             R(Text("try:") + Key("enter:2/10, backspace") + Text("except Exception:") +
-              Key("enter"),
-              rdescript="Python: Try Catch"),
+              Key("enter")),
     }
 
 
@@ -32,91 +31,88 @@ class Python(MergeRule):
 
     mapping = {
         SymbolSpecs.IF:
-            R(Key("i,f,space,colon,left"), rdescript="Python: If"),
+            R(Key("i,f,space,colon,left")),
         SymbolSpecs.ELSE:
-            R(Text("else:") + Key("enter"), rdescript="Python: Else"),
+            R(Text("else:") + Key("enter")),
         # (no switch in Python)
         SymbolSpecs.BREAK:
-            R(Text("break"), rdescript="Python: Break"),
+            R(Text("break")),
         SymbolSpecs.FOR_EACH_LOOP:
-            R(Text("for  in :") + Key("left:5"), rdescript="Python: For Each Loop"),
+            R(Text("for  in :") + Key("left:5")),
         SymbolSpecs.FOR_LOOP:
-            R(Text("for i in range(0, ):") + Key("left:2"),
-              rdescript="Python: For i Loop"),
+            R(Text("for i in range(0, ):") + Key("left:2")),
         SymbolSpecs.WHILE_LOOP:
-            R(Text("while :") + Key("left"), rdescript="Python: While"),
+            R(Text("while :") + Key("left")),
         # (no do-while in Python)
         SymbolSpecs.TO_INTEGER:
-            R(Text("int()") + Key("left"), rdescript="Python: Convert To Integer"),
+            R(Text("int()") + Key("left")),
         SymbolSpecs.TO_FLOAT:
-            R(Text("float()") + Key("left"),
-              rdescript="Python: Convert To Floating-Point"),
+            R(Text("float()") + Key("left")),
         SymbolSpecs.TO_STRING:
-            R(Text("str()") + Key("left"), rdescript="Python: Convert To String"),
+            R(Text("str()") + Key("left")),
         SymbolSpecs.AND:
-            R(Text(" and "), rdescript="Python: And"),
+            R(Text(" and ")),
         SymbolSpecs.OR:
-            R(Text(" or "), rdescript="Python: Or"),
+            R(Text(" or ")),
         SymbolSpecs.NOT:
-            R(Text("!"), rdescript="Python: Not"),
+            R(Text("!")),
         SymbolSpecs.SYSOUT:
-            R(Text("print()") + Key("left"), rdescript="Python: Print"),
+            R(Text("print()") + Key("left")),
         SymbolSpecs.IMPORT:
-            R(Text("import "), rdescript="Python: Import"),
+            R(Text("import ")),
         SymbolSpecs.FUNCTION:
-            R(Text("def ():") + Key("left:3"), rdescript="Python: Function"),
+            R(Text("def ():") + Key("left:3")),
         SymbolSpecs.CLASS:
-            R(Text("class :") + Key("left"), rdescript="Python: Class"),
+            R(Text("class :") + Key("left")),
         SymbolSpecs.COMMENT:
-            R(Text("#"), rdescript="Python: Add Comment"),
+            R(Text("#")),
         SymbolSpecs.LONG_COMMENT:
-            R(Text("''''''") + Key("left:3"), rdescript="Python: Long Comment"),
+            R(Text("''''''") + Key("left:3")),
         SymbolSpecs.NULL:
-            R(Text("None"), rdescript="Python: Null"),
+            R(Text("None")),
         SymbolSpecs.RETURN:
-            R(Text("return "), rdescript="Python: Return"),
+            R(Text("return ")),
         SymbolSpecs.TRUE:
-            R(Text("True"), rdescript="Python: True"),
+            R(Text("True")),
         SymbolSpecs.FALSE:
-            R(Text("False"), rdescript="Python: False"),
+            R(Text("False")),
 
         # Python specific
         "sue iffae":
-            R(Text("if "), rdescript="Python: Short If"),
+            R(Text("if ")),
         "sue shells":
-            R(Text("else "), rdescript="Python: Short Else"),
+            R(Text("else ")),
         "from":
-            R(Text("from "), rdescript="Python: From"),
+            R(Text("from ")),
         "self":
-            R(Text("self"), rdescript="Python: Self"),
+            R(Text("self")),
         "long not":
-            R(Text(" not "), rdescript="Python: Long Not"),
+            R(Text(" not ")),
         "it are in":
-            R(Text(" in "), rdescript="Python: In"),  #supposed to sound like "iter in"
+            R(Text(" in ")),
         "shell iffae | LFA":
-            R(Key("e,l,i,f,space,colon,left"), rdescript="Python: Else If"),
+            R(Key("e,l,i,f,space,colon,left")),
         "convert to character":
-            R(Text("chr()") + Key("left"), rdescript="Python: Convert To Character"),
+            R(Text("chr()") + Key("left")),
         "length of":
-            R(Text("len()") + Key("left"), rdescript="Python: Length"),
+            R(Text("len()") + Key("left")),
         "global":
-            R(Text("global "), rdescript="Python: Global"),
+            R(Text("global ")),
         "make assertion":
-            R(Text("assert "), rdescript="Python: Assert"),
+            R(Text("assert ")),
         "list (comprehension | comp)":
-            R(Text("[x for x in TOKEN if TOKEN]"),
-              rdescript="Python: List Comprehension"),
+            R(Text("[x for x in TOKEN if TOKEN]")),
 
         "[dot] (pie | pi)":
-            R(Text(".py"), rdescript="Python: .py"),
+            R(Text(".py")),
         "toml":
-            R(Text("toml"), rdescript="Python: toml"),
+            R(Text("toml")),
         "jason":
-            R(Text("toml"), rdescript="Python: json"),
+            R(Text("toml")),
         "identity is":
-            R(Text(" is "), rdescript="Python: is"),
+            R(Text(" is ")),
         "yield":
-            R(Text("yield "), rdescript="Python: Yield"),
+            R(Text("yield ")),
 
         # Essentially an improved version of the try catch command above
             # probably a better option than this is to use snippets with tab stops
@@ -126,20 +122,17 @@ class Python(MergeRule):
             # you can also make your own snippets.
         "try [<exception>]":
             R(Text("try : ") + Pause("10") + Key("enter/2")
-            + Text("except %(exception)s:") + Pause("10") + Key("enter/2"),
-                rdescript="create 'try catch' block with given exception"),
+            + Text("except %(exception)s:") + Pause("10") + Key("enter/2")),
         "try [<exception>] as":
             R(Text("try :") + Pause("10") + Key("enter/2") + Text("except %(exception)s as :")
-            + Pause("10") + Key("enter/2"),  rdescript="create 'try catch as' block with given exception"),
+            + Pause("10") + Key("enter/2")),
 
         # class and class methods
-        "subclass": R(Text("class ():") + Key("left:3"), rdescript="Python: Subclass"),
-        "dunder": R(Text("____()") + Key("left:4"),  rdescript="Python: Special Method"),
-        "init": R(Text("__init__()") + Key("left"),  rdescript="Python: Init"),
-        "meth [<binary_meth>]": R(Text("__%(binary_meth)s__(self, other):"),
-            rdescript="Python: Binary Special Method"),
-        "meth [<unary_meth>]": R(Text("__%(unary_meth)s__(self):"),
-            rdescript="Python: Unary Special Method"),
+        "subclass": R(Text("class ():") + Key("left:3")),
+        "dunder": R(Text("____()") + Key("left:4")),
+        "init": R(Text("__init__()") + Key("left")),
+        "meth [<binary_meth>]": R(Text("__%(binary_meth)s__(self, other):")),
+        "meth [<unary_meth>]": R(Text("__%(unary_meth)s__(self):")),
     }
 
     extras = [

--- a/castervoice/lib/dfplus/merge/mergerule.py
+++ b/castervoice/lib/dfplus/merge/mergerule.py
@@ -75,7 +75,7 @@ class MergeRule(MappingRule):
     def format_actions(self):
         def create_rdescript(command, raction):
             extras = ""
-            named_extras = re.findall(r"<(.*)>", command)
+            named_extras = re.findall(r"<(.*?)>", command)
             if named_extras:
                 extras = ", %(" + ")s, %(".join(named_extras) + ")s"
             return "%s: %s%s" % (self.name, command, extras)

--- a/castervoice/lib/dfplus/merge/mergerule.py
+++ b/castervoice/lib/dfplus/merge/mergerule.py
@@ -4,7 +4,8 @@ Created on Sep 1, 2015
 @author: synkarius
 '''
 from dragonfly import MappingRule, Pause, Function
-
+# from castervoice.lib.dfplus.state.short import R
+import re
 
 class MergeRule(MappingRule):
     @staticmethod
@@ -24,10 +25,10 @@ class MergeRule(MappingRule):
     for their respective enable/disable commands'''
     pronunciation = None
     '''MergeRules which define `non` will instantiate
-    their paired non-CCR MergeRule and activate it 
+    their paired non-CCR MergeRule and activate it
     alongside themselves'''
     non = None
-    '''MergeRules which define `mcontext` with a 
+    '''MergeRules which define `mcontext` with a
     Dragonfly AppContext become non-global; this
     is the same as adding a context to a Grammar'''
     mcontext = None
@@ -63,11 +64,25 @@ class MergeRule(MappingRule):
                 lambda: self._display_available_commands())
 
         MappingRule.__init__(self, name, mapping, extras, defaults, exported)
+        self.format_actions()
+
 
     def __eq__(self, other):
         if not isinstance(other, MergeRule):
             return False
         return self.ID == other.ID
+
+    def format_actions(self):
+        def create_rdescript(command, raction):
+            extras = ""
+            named_extras = re.findall(r"<(.*)>", command)
+            if named_extras:
+                extras = ", %(" + ")s, %(".join(named_extras) + ")s"
+            return "%s: %s%s" % (self.name, command, extras)
+        for command, action in self.mapping.items():
+            if hasattr(action, "rdescript") and action.rdescript is None:
+                self.mapping[command].rdescript = create_rdescript(command, action)
+
 
     ''' "copy" getters used for safe merging;
     "actual" versions used for filter functions'''

--- a/castervoice/lib/dfplus/state/actions.py
+++ b/castervoice/lib/dfplus/state/actions.py
@@ -22,11 +22,6 @@ class RegisteredAction(ActionBase):
         self.show = show
 
     def _execute(self, data=None):
-        # formats rdescript with the given data
-        try:
-            self.rdescript = self.rdescript % data
-        except:
-            pass
         # copies everything relevant and places it in the stack
         self.nexus().state.add(StackItemRegisteredAction(self, data))
 

--- a/castervoice/lib/dfplus/state/actions.py
+++ b/castervoice/lib/dfplus/state/actions.py
@@ -10,7 +10,7 @@ class RegisteredAction(ActionBase):
     def __init__(self,
                  base,
                  rspec="default",
-                 rdescript="unnamed command (RA)",
+                 rdescript=None,
                  rundo=None,
                  show=True):
         ActionBase.__init__(self)
@@ -21,8 +21,13 @@ class RegisteredAction(ActionBase):
         self.rundo = rundo
         self.show = show
 
-    def _execute(self,
-                 data=None):  # copies everything relevant and places it in the stack
+    def _execute(self, data=None):
+        # formats rdescript with the given data
+        try:
+            self.rdescript = self.rdescript % data
+        except:
+            pass
+        # copies everything relevant and places it in the stack
         self.nexus().state.add(StackItemRegisteredAction(self, data))
 
     def set_nexus(self, nexus):
@@ -56,7 +61,7 @@ class AsynchronousAction(ContextSeeker):
     AsynchronousAction should have exactly one ContextLevel with one ContextSet.
     Any triggers in the 0th ContextSet will terminate the AsynchronousAction.
     The repetitions parameter indicates the maximum times the function provided
-    in the 0th ContextSet should run. 0 indicates forever (or until the 
+    in the 0th ContextSet should run. 0 indicates forever (or until the
     termination word is spoken). The time_in_seconds parameter indicates
     how often the associated function should run.
     '''
@@ -90,9 +95,9 @@ class AsynchronousAction(ContextSeeker):
 
     @staticmethod
     def hmc_complete(data_function, nexus):
-        ''' returns a function which applies the passed in function to 
+        ''' returns a function which applies the passed in function to
         the data returned by the pop-up window - the returned function
-        will be called by AsynchronousAction's timer repeatedly, 
+        will be called by AsynchronousAction's timer repeatedly,
         to see if the data is available yet'''
 
         def check_complete():

--- a/castervoice/lib/dfplus/state/actions.py
+++ b/castervoice/lib/dfplus/state/actions.py
@@ -21,6 +21,10 @@ class RegisteredAction(ActionBase):
         self.rundo = rundo
         self.show = show
 
+    def __mul__(self, factor):
+        self.base = self.base * factor
+        return self
+
     def _execute(self, data=None):
         # copies everything relevant and places it in the stack
         self.nexus().state.add(StackItemRegisteredAction(self, data))

--- a/castervoice/lib/dfplus/state/stack.py
+++ b/castervoice/lib/dfplus/state/stack.py
@@ -88,11 +88,11 @@ class ContextStack:
                 seeker.satisfy_level(index, True, prior_stack_item)
                 seeker.get_parameters(index, prior_stack_item)
         ''' case: there are forward seekers in the stack --
-            -- every incomplete seeker has the reach to 
+            -- every incomplete seeker has the reach to
                get a level from this stack item, so make
-               a list of incomplete forward seekers, feed 
-               the new stack item to each of them in order, 
-               then check them each for completeness in order 
+               a list of incomplete forward seekers, feed
+               the new stack item to each of them in order,
+               then check them each for completeness in order
                and if they are complete, execute them in FIFO order'''
         incomplete = self.get_incomplete_seekers()
         number_incomplete = len(incomplete)
@@ -118,9 +118,9 @@ class ContextStack:
         stack_item_is_forward_seeker = stack_item.type == StackItemSeeker.TYPE and stack_item.forward is not None
         stack_item_is_continuer = ContextStack.is_asynchronous(stack_item.type)
         if not stack_item.consumed and not stack_item_is_forward_seeker and not stack_item_is_continuer:
-            stack_item.execute()
             stack_item.put_time_action(
             )  # this is where display window information will happen
+            stack_item.execute()
         elif stack_item_is_continuer:
             stack_item.begin()
             stack_item.put_time_action()

--- a/castervoice/lib/dfplus/state/stackitems.py
+++ b/castervoice/lib/dfplus/state/stackitems.py
@@ -48,7 +48,7 @@ class StackItemRegisteredAction(StackItem):
         self.base = None
 
     def preserve(self):
-        '''save the useful parts of the incoming dragonfly data 
+        '''save the useful parts of the incoming dragonfly data
         (in this case, spoken words)'''
         if self.dragonfly_data is not None:
             self.preserved = [x[0] for x in self.dragonfly_data["_node"].results]
@@ -61,7 +61,12 @@ class StackItemRegisteredAction(StackItem):
     def put_time_action(self):
         self.preserve()
         if settings.SETTINGS["miscellaneous"]["print_rdescripts"] and self.show:
-            print(self.rdescript)
+            # formats rdescript with the given data
+            try:
+                rd = self.rdescript % self.dragonfly_data
+            except:
+                rd = self.rdescript
+            print(rd)
 
 
 class StackItemSeeker(StackItemRegisteredAction):


### PR DESCRIPTION
Currently, the accepted formatting for a caster command looks something like this:
```
"function": R(Text("def ():") + Key("left:2"), rdescript="Python: function"),
```

We have the verbal command, R - which creates a registered action, the actual dragonfly objects to be executed, and an rdescript written by whoever wrote the grammar to describe the command.

There are a number of problems with this construction.

1. It's long, often requiring multiple lines to define a single command.
2. It's verbose, only about half of the character count is actually useful code, the rest is verbiage.
3. It's a bug magnet, with a lot of potential for misplaced commas and brackets and misspelled words.
4. rdescripts are inconsistent between different authors and are a pain to write.

The combination of these problems end up making the code base harder to read and harder to work on, with little appreciable benefit.

The aim of this pull request is to radically simplify this construction, pushing stuff which should really be backend into the backend and out of the user's way. 

So far I have:
* Altered the execution of registered action so that dynamic elements can be added into the rdescript.
* Altered the merge rule so that all registered actions which do not have an rdescript will be given one, containing the name of the class, the command spec, and the extras to be dynamically added on execution.
* Deleted all rdescripts from the Python module for testing purposes.

A further improvement would be to have dragonfly objects be automatically converted to registered actions, removing the need for `R` as well. This should be possible but needs some work, as at the moment it causes a nasty dependency cycle.

Happy to get any thoughts.