### PR TITLE
Fixed error in section "Template-based navigation"

### DIFF
--- a/castervoice/doc/CasterQuickReference.tex
+++ b/castervoice/doc/CasterQuickReference.tex
@@ -348,7 +348,7 @@ Capitalisation and spacing can be combined into a single command. Whether combin
 \command{jump in \footnotemark[2]}{move cursor inside next ([\{<}
 \command{jump out \footnotemark[2]}{move cursor past next )]\}>}
 \command{jump back \footnotemark[2]}{move cursor inside prev )]\}>}
-\command{jump in \footnotemark[2]}{highlight <target> in line}
+\command{fill <target> \footnotemark[2]}{highlight <target> in line}
 
 \footnotetext[2]{All of these are asynchronous, and can be cancelled with the word "cancel" if the search is taking too long. See \textit{navigation.py} for a full list of targets.}
 


### PR DESCRIPTION
There was an error in the "Template-based navigation" a section. It said "jump in" instead of "fill <target>".