### PR TITLE
Add and adjust keystroke commands in nav.py

### DIFF
--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -232,8 +232,16 @@ class Navigation(MergeRule):
         "spark [<nnavi500>] [(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)]":
             R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark", rdescript="Core: Paste"),
 
-        "splat [<splatdir>] [<nnavi10>]":
-            R(Key("c-%(splatdir)s"), rspec="splat", rdescript="Core: Splat") * Repeat(extra="nnavi10"),
+        "splat [<nnavi50>]": 
+            R(Key("cs-left:%(nnavi50)s, del"), rspec="splat",  
+            rdescript="Core: delete words to the left"),
+        "sprat [<nnavi50>]":
+            R(Key("cs-right:%(nnavi50)s, del"), rspec="sprat",  
+            rdescript="Core: delete words to the right"),
+        "splat wally":
+            R(Key("s-home, del"), rspec="splat wally", rdescript="Core: delete left till end of line"),
+        "sprat wally":
+            R(Key("s-end, del"), rspec="sprat wally", rdescript="Core: delete right till end of line "),
         "deli [<nnavi50>]":
             R(Key("del/5"), rspec="deli", rdescript="Core: Delete") * Repeat(extra="nnavi50"),
         "clear [<nnavi50>]":

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -232,6 +232,14 @@ class Navigation(MergeRule):
         "spark [<nnavi500>] [(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)]":
             R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark", rdescript="Core: Paste"),
 
+        
+        "shin deli [<nnavi50>]":
+            R(Key("s-del/5"), rspec="shift deli", rdescript="Core:hard Delete") * Repeat(extra="nnavi50"),
+        "shin tabby [<nnavi50>]":
+            R(Key("s-tab/5"), rspec="shift tabby", rdescript="Core: shift tab") * Repeat(extra="nnavi50"),
+        'shin shock [<nnavi50>]':
+            R(Key("s-enter"), rspec="shift shock", rdescript="Core: Shift Enter")* Repeat(extra="nnavi50"),
+
         "splat [<nnavi50>]": 
             R(Key("cs-left:%(nnavi50)s, del"), rspec="splat",  
             rdescript="Core: delete words to the left"),
@@ -258,6 +266,8 @@ class Navigation(MergeRule):
             R(Function(navigation.duple_keep_clipboard), rspec="duple", rdescript="Core: Duplicate Line"),
         "Kraken":
             R(Key("c-space"), rspec="Kraken", rdescript="Core: Control Space"),
+        "dropdown list": 
+            R(Key("a-down"), rspec="dropdown list", rdescript="Core: drop down a drop down list"),
 
     # text formatting
         "set [<big>] format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":

--- a/castervoice/lib/navigation.py
+++ b/castervoice/lib/navigation.py
@@ -233,8 +233,8 @@ def curse(direction, direction2, nnavi500, dokick):
 def next_line(semi):
     semi = str(semi)
     Key("escape").execute()
-    time.sleep(0.25)
+    time.sleep(0.05)
     Key("end").execute()
-    time.sleep(0.25)
+    time.sleep(0.05)
     Text(semi).execute()
     Key("enter").execute()


### PR DESCRIPTION
Pressing control backspace doesn't work in all application so I changed it to use control shift left/right delete. Also, as it was, "splat lease" was sometimes interpreted as to commands and sometimes interpreted as one. I remove this ambiguity by making "splat" for deleting words to the left and "sprat" for deleting words to the right.