### PR TITLE
Make userspace rules work after changing profile

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -59,10 +59,11 @@ from castervoice.lib.dfplus.hint.nodes import css
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.merge import gfilter
 
-# Load user rules
-_NEXUS.process_user_content()
-_NEXUS.merger.update_config()
-_NEXUS.merger.merge(MergeInf.BOOT)
+if not globals().has_key('profile_switch_occurred'):
+    # Load user rules
+    _NEXUS.process_user_content()
+    _NEXUS.merger.update_config()
+    _NEXUS.merger.merge(MergeInf.BOOT)
 
 
 # Checks if install is classic or PIP of caster


### PR DESCRIPTION
Fixes #508 by loading userspace rules only once - when DNS is started for the first time - and not when you switch to a different profile.