### PR TITLE
Remove the '+' from the `dev pause' command.

### DIFF
--- a/castervoice25/lib26/ccr27/voice_dev_commands28/voice_dev_commands.py
+++ b/castervoice25/lib26/ccr27/voice_dev_commands28/voice_dev_commands.py
@@ -89,7 +89,7 @@ class VoiceDevCommands(MergeRule):
         "dev text":
             R(Text('Text("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Text Action"),
         "dev pause":
-            R(Text(' + Pause("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Pause Action"),
+            R(Text('Pause("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Pause Action"),
         "dev function":
             R(Text("Function()") + Key("left")),
         "dev repeat":


### PR DESCRIPTION
I first put in the '+' because the Pause action is often used in conjunction with other actions and so often requires the plus before it. But after more experience using these commands, I think it is better just to be consistent and not put the plus in front.
(by the way, this is my first ball request made using the gui as opposed to the command line so it works)