### PR TITLE
Handle case when 'PROCESSOR_ARCHITEW6432' is not an environment var

### DIFF
--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 
 import collections
@@ -79,7 +80,10 @@ def _find_natspeak():
     '''
     print("Searching Windows Registry For DNS...")
     proc_arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
-    proc_arch64 = os.environ['PROCESSOR_ARCHITEW6432'].lower()
+    try:
+        proc_arch64 = os.environ['PROCESSOR_ARCHITEW6432'].lower()
+    except KeyError:
+        proc_arch64 = False
 
     if proc_arch == 'x86' and not proc_arch64:
         arch_keys = {0}


### PR DESCRIPTION
Addresses #516. Added error handling for case when 'PROCESSOR_ARCHITEW6432' is not set as an environment variable.