### PR TITLE
HTML workaround for Jetbrains IDE auto complete #541

### DIFF
--- a/castervoice/lib/actions.py
+++ b/castervoice/lib/actions.py
@@ -17,3 +17,19 @@ if settings.SETTINGS["miscellaneous"]["use_aenea"]:
     except ImportError:
         print("Unable to import aenea actions. Dragonfly actions will be used "
               "instead.")
+
+
+class Text(TextBase):
+    # dragonfly default is 0.02, too slow!
+    _pause_default = 0.003
+    def __init__(self, spec=None, static=False, pause=_pause_default, autofmt=False, use_hardware=False):
+        TextBase.__init__(self, spec=spec, static=static, pause=pause, autofmt=autofmt, use_hardware=use_hardware)
+
+# Override imported dragonfly actions with aenea's if the 'use_aenea' setting
+# is set to true.
+if settings.SETTINGS["miscellaneous"]["use_aenea"]:
+    try:
+        from aenea import Key, Text, Mouse
+    except ImportError:
+        print("Unable to import RDP actions. Dragonfly actions will be used "
+              "instead.")

--- a/castervoice/lib/ccr/html/html.py
+++ b/castervoice/lib/ccr/html/html.py
@@ -8,12 +8,8 @@ from castervoice.lib import settings
 
 # HTML auto complete workaround for Jetbrains Products
 # If more applications have issues with auto complete may be moved to actions.py
-context = AppContext(executable="idea", title="IntelliJ") \
-    | AppContext(executable="idea64", title="IntelliJ") \
-    | AppContext(executable="studio64") \
-    | AppContext(executable="pycharm")  \
-    | AppContext(executable="webstorm64") \
-    | AppContext(executable="webstorm")
+context = AppContext(executable=["idea", "idea64", "studio64", "pycharm", "webstorm64", "webstorm"])
+
 if context:
     from dragonfly.actions.action_paste import Paste as Text
     if settings.SETTINGS["miscellaneous"]["use_aenea"]:

--- a/castervoice/lib/ccr/html/html.py
+++ b/castervoice/lib/ccr/html/html.py
@@ -1,8 +1,29 @@
 
 from castervoice.lib import control
-from castervoice.lib.actions import Key, Text
+from castervoice.lib.context import AppContext
+from castervoice.lib.actions import Key
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
+from castervoice.lib import settings
+
+# HTML auto complete workaround for Jetbrains Products
+# If more applications have issues with auto complete may be moved to actions.py
+context = AppContext(executable="idea", title="IntelliJ") \
+    | AppContext(executable="idea64", title="IntelliJ") \
+    | AppContext(executable="studio64") \
+    | AppContext(executable="pycharm")  \
+    | AppContext(executable="webstorm64") \
+    | AppContext(executable="webstorm")
+if context:
+    from dragonfly.actions.action_paste import Paste as Text
+    if settings.SETTINGS["miscellaneous"]["use_aenea"]:
+        try:
+            from aenea import Paste as Text
+        except ImportError:
+            print("Unable to import aenea Paste actions. Dragonfly actions will be used "
+            "instead.")
+else: 
+    from castervoice.lib.actions import Text
 
 class HTML(MergeRule):
     mapping = {


### PR DESCRIPTION
This will request contextually changes imports `Text `to `Paste` based on AppContext for all supported Jetbrains products.
 `from dragonfly.actions.action_paste import Paste as Text`