### PR TITLE
Add default for mwith

### DIFF
--- a/castervoice/apps/vscode.py
+++ b/castervoice/apps/vscode.py
@@ -10,7 +10,6 @@ from castervoice.lib.dfplus.additions import IntegerRefST
 from castervoice.lib.dfplus.merge import gfilter
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
-from castervoice.lib.dfplus.merge.ccrmerger import CCRMerger
 
 
 def findNthToken(text, n, direction):
@@ -297,7 +296,6 @@ class VSCodeNonCcrRule(MergeRule):
 
 class VSCodeCcrRule(MergeRule):
     pronunciation = "visual studio code continuous"
-    mwith = CCRMerger.CORE
     non = VSCodeNonCcrRule
 
     mapping = {

--- a/castervoice/lib/dfplus/merge/ccrmerger.py
+++ b/castervoice/lib/dfplus/merge/ccrmerger.py
@@ -122,9 +122,8 @@ class CCRMerger(object):
         assert rule.get_context(
         ) is not None, "app rules must have contexts, " + rule.get_pronunciation(
         ) + " has no context"
-        assert rule.get_merge_with(
-        ) is not None, "app rules must define mwith, " + rule.get_pronunciation(
-        ) + " has no mwith"
+        if rule.get_merge_with() is None:
+            rule.set_merge_with(CCRMerger.CORE)
         self._add_to(rule, self._app_rules)
 
     def add_selfmodrule(self, rule):

--- a/castervoice/lib/dfplus/merge/mergerule.py
+++ b/castervoice/lib/dfplus/merge/mergerule.py
@@ -35,7 +35,10 @@ class MergeRule(MappingRule):
     '''app MergeRules MUST define `mwith` in order to
     define what else they can merge with -- this is an
     optimization to prevent pointlessly large global
-    CCR copies; mwith is a list of get_pronunciation()s'''
+    CCR copies; mwith is a list of get_pronunciation()s.
+    If a rule is added with no mwith, mwith will be set
+    to CCRMerger.CORE
+    '''
     mwith = None
 
     def __init__(self,
@@ -158,6 +161,9 @@ class MergeRule(MappingRule):
 
     def get_merge_with(self):
         return self._mwith
+
+    def set_merge_with(self, mwith):
+        self._mwith = mwith
 
     def _display_available_commands(self):
         for spec in self.mapping_actual().keys():


### PR DESCRIPTION
Small alteration to make adding app CCR rules easier. If no `mwith` is defined in the rule then this will default to `CCRMerger.CORE` when the rule is added rather than throwing an error. This is a sensible default I think and saves importing `CCRMerger` into every rule. Relevant to #571.