### PR TITLE
fix duplication commands in chrome

### DIFF
--- a/castervoice/apps/chrome.py
+++ b/castervoice/apps/chrome.py
@@ -121,9 +121,9 @@ class ChromeRule(MergeRule):
             R(Store(space="+", remove_cr=True) + Key("c-t") + Text("https://en.wikipedia.org/w/index.php?search=") + Retrieve() + Key("enter")),
 
         "duplicate tab":
-            R(Key("a-d,a-c,c-t/15,c-v/15, enter")),
-        "duplicate window":
-            R(Key("a-d,a-c,c-n/15,c-v/15, enter")),
+            R(Key("a-d,c-c/20,c-t,c-v, enter"), rdescript="make new tab and go to current URL"),
+        "duplicate tab in new window":
+            R(Key("a-d,c-c/20,c-n,c-v, enter"), rdescript="make new window and go to current URL"),             
         "extensions":
             R(Key("a-f/20, l, e/15, enter")),
         "(menu | three dots)":


### PR DESCRIPTION
I increased the wait time after pressing control c, and I took out other unnecessary waits. Also, the command spec "duplicate window" was causing some crazy behavior I don't know why, possibly because that is another command somewhere? Anyways, I changed it to "duplicate tab in the window" which is working well now.