### PR TITLE
Rule loading functions in control.py

### DIFF
--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -18,10 +18,10 @@ Commands for easily loading different types of rules, e.g.:
 control.non_ccr_app_rule(FirefoxRule(), AppContext("firefox"))
 '''
 def non_ccr_app_rule(rule, context=None):
-    grammar = Grammar(context=context)
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
         nexus().merger.add_global_rule(rule)
     else:
+        grammar = Grammar(str(rule), context=context)
         gfilter.run_on(rule)
         grammar.add_rule(rule)
         grammar.load()

--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -1,10 +1,36 @@
+from dragonfly import Grammar
+
 from castervoice.lib.ctrl.nexus import Nexus
+from castervoice.lib import settings
+from castervoice.lib.dfplus.merge import gfilter
 
 _NEXUS = None
-
 
 def nexus():
     global _NEXUS
     if _NEXUS is None:
         _NEXUS = Nexus()
     return _NEXUS
+
+
+'''
+Commands for easily loading different types of rules, e.g.:
+control.non_ccr_app_rule(FirefoxRule(), AppContext("firefox"))
+'''
+def non_ccr_app_rule(rule, context=None):
+    grammar = Grammar(context=context)
+    if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
+        nexus().merger.add_global_rule(rule)
+    else:
+        gfilter.run_on(rule)
+        grammar.add_rule(rule)
+        grammar.load()
+
+def ccr_app_rule(rule, context=None):
+    nexus().merger.add_app_rule(rule, context=context)
+
+def global_rule(rule):
+    nexus().merger.add_global_rule(rule)
+
+def selfmod_rule(rule):
+    nexus().merger.add_selfmod_rule(rule)

--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -21,6 +21,8 @@ def non_ccr_app_rule(rule, context=None, name=None):
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
         nexus().merger.add_global_rule(rule)
     else:
+        if hasattr(rule, get_context) and rule.get_context() is not None:
+            context = rule.get_context()
         grammar_name = name if name else str(rule)
         grammar = Grammar(grammar_name, context=context)
         gfilter.run_on(rule)

--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -21,7 +21,7 @@ def non_ccr_app_rule(rule, context=None, name=None):
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
         nexus().merger.add_global_rule(rule)
     else:
-        if hasattr(rule, get_context) and rule.get_context() is not None:
+        if hasattr(rule, "get_context") and rule.get_context() is not None:
             context = rule.get_context()
         grammar_name = name if name else str(rule)
         grammar = Grammar(grammar_name, context=context)

--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -17,11 +17,12 @@ def nexus():
 Commands for easily loading different types of rules, e.g.:
 control.non_ccr_app_rule(FirefoxRule(), AppContext("firefox"))
 '''
-def non_ccr_app_rule(rule, context=None):
+def non_ccr_app_rule(rule, context=None, name=None):
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
         nexus().merger.add_global_rule(rule)
     else:
-        grammar = Grammar(str(rule), context=context)
+        grammar_name = name if name else str(rule)
+        grammar = Grammar(grammar_name, context=context)
         gfilter.run_on(rule)
         grammar.add_rule(rule)
         grammar.load()

--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -33,4 +33,4 @@ def global_rule(rule):
     nexus().merger.add_global_rule(rule)
 
 def selfmod_rule(rule):
-    nexus().merger.add_selfmod_rule(rule)
+    nexus().merger.add_selfmodrule(rule)


### PR DESCRIPTION
As mentioned in #589  I have implemented a series of functions in `control.py` to simplify and standardise the API for adding rules.

The only question I have at the moment is about lines like:
```
if settings.SETTINGS["apps"]["firefox"]:
```

Which only load app rules if the relevant value is set to true in the settings. Is there a good reason why this is necessary? Does anybody need the ability to disable particular app rules (perhaps RDP users)? @LexiconCode