### PR TITLE
Further tidying of rule loading

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -65,9 +65,7 @@ from castervoice.lib.dfplus.additions import IntegerRefST
 
 from castervoice.lib.dfplus.merge.mergepair import MergeInf
 from castervoice.lib.ccr import *
-from castervoice.lib.ccr.recording.again import Again
-from castervoice.lib.ccr.recording.bringme import bring_rule
-from castervoice.lib.ccr.recording.alias import Alias
+from castervoice.lib.ccr.recording import again, bringme, alias
 from castervoice.lib.ccr.recording import history
 from castervoice.lib.dev import dev
 from castervoice.lib.dfplus.hint.nodes import css
@@ -202,53 +200,43 @@ class MainRule(MergeRule):
     mapping = {
         # update management
         "update caster":
-            R(DependencyUpdate([PIP_PATH, "install", "--upgrade", "castervoice"]),
-              rdescript="Core: Update and restart Caster"),
+            R(DependencyUpdate([PIP_PATH, "install", "--upgrade", "castervoice"])),
         "update dragonfly":
-            R(DependencyUpdate([PIP_PATH, "install", "--upgrade", "dragonfly2"]),
-              rdescript="Core: Update dragonfly2 and restart Caster"),
+            R(DependencyUpdate([PIP_PATH, "install", "--upgrade", "dragonfly2"])),
 
         # hardware management
         "volume <volume_mode> [<n>]":
-            R(Function(navigation.volume_control, extra={'n', 'volume_mode'}),
-              rdescript="Volume Control"),
+            R(Function(navigation.volume_control, extra={'n', 'volume_mode'})),
         "change monitor":
-            R(Key("w-p") + Pause("100") + Function(change_monitor),
-              rdescript="Change Monitor"),
+            R(Key("w-p") + Pause("100") + Function(change_monitor)),
 
         # window management
         'minimize':
-            R(Playback([(["minimize", "window"], 0.0)]), rdescript="Minimize Window"),
+            R(Playback([(["minimize", "window"], 0.0)])),
         'maximize':
-            R(Playback([(["maximize", "window"], 0.0)]), rdescript="Maximize Window"),
+            R(Playback([(["maximize", "window"], 0.0)])),
         "remax":
-            R(Key("a-space/10,r/10,a-space/10,x"), rdescript="Force Maximize Window"),
+            R(Key("a-space/10,r/10,a-space/10,x")),
 
         # passwords
 
         # mouse alternatives
         "legion [<monitor>]":
-            R(Function(navigation.mouse_alternates, mode="legion", nexus=_NEXUS),
-              rdescript="Activate Legion"),
+            R(Function(navigation.mouse_alternates, mode="legion", nexus=_NEXUS)),
         "rainbow [<monitor>]":
-            R(Function(navigation.mouse_alternates, mode="rainbow", nexus=_NEXUS),
-              rdescript="Activate Rainbow Grid"),
+            R(Function(navigation.mouse_alternates, mode="rainbow", nexus=_NEXUS)),
         "douglas [<monitor>]":
-            R(Function(navigation.mouse_alternates, mode="douglas", nexus=_NEXUS),
-              rdescript="Activate Douglas Grid"),
+            R(Function(navigation.mouse_alternates, mode="douglas", nexus=_NEXUS)),
 
         # ccr de/activation
         "<enable> <name>":
-            R(Function(_NEXUS.merger.global_rule_changer(), save=True),
-              rdescript="Toggle CCR Module"),
+            R(Function(_NEXUS.merger.global_rule_changer(), save=True)),
         "<enable> <name2>":
-            R(Function(_NEXUS.merger.selfmod_rule_changer(), save=True),
-              rdescript="Toggle sm-CCR Module"),
+            R(Function(_NEXUS.merger.selfmod_rule_changer(), save=True)),
         "enable caster":
-            R(Function(_NEXUS.merger.merge, time=MergeInf.RUN, name="numbers"),
-              rdescript="Enable CCR rules"),
+            R(Function(_NEXUS.merger.merge, time=MergeInf.RUN, name="numbers")),
         "disable caster":
-            R(Function(_NEXUS.merger.ccr_off), rdescript="Disable CCR rules"),
+            R(Function(_NEXUS.merger.ccr_off)),
     }
     extras = [
         IntegerRefST("n", 1, 50),
@@ -270,26 +258,8 @@ class MainRule(MergeRule):
     ]
     defaults = {"n": 1, "nnv": 1, "text": "", "volume_mode": "setsysvolume", "enable": -1}
 
+control.non_ccr_app_rule(MainRule(), context=None, rdp=False)
 
-grammar = Grammar('general')
-main_rule = MainRule()
-gfilter.run_on(main_rule)
-grammar.add_rule(main_rule)
-
-gfilter.run_on(bring_rule)
-grammar.add_rule(bring_rule)
-
-if settings.SETTINGS["feature_rules"]["again"]:
-    again_rule = Again(_NEXUS)
-    gfilter.run_on(again_rule)
-    grammar.add_rule(again_rule)
-
-if settings.SETTINGS["feature_rules"]["alias"]:
-    alias_rule = Alias(_NEXUS)
-    gfilter.run_on(alias_rule)
-    grammar.add_rule(alias_rule)
-
-grammar.load()
 
 if globals().has_key('profile_switch_occurred'):
     reload(sikuli)

--- a/_caster.py
+++ b/_caster.py
@@ -50,27 +50,22 @@ if settings.WSR:
     SymbolSpecs.set_cancel_word("escape")
 from castervoice.lib import control
 _NEXUS = control.nexus()
+from castervoice.lib import navigation
+navigation.initialize_clipboard(_NEXUS)
 
 from castervoice.apps import __init__
 from castervoice.asynch import *
-from castervoice.lib import context
-from castervoice.lib.actions import Key
-from castervoice.lib.terminal import TerminalCommand
+from castervoice.lib.ccr import *
+from castervoice.lib.ccr.recording import bringme, again, alias, history
 import castervoice.lib.dev.dev
 from castervoice.asynch.sikuli import sikuli
-from castervoice.lib import navigation
-navigation.initialize_clipboard(_NEXUS)
+
+from castervoice.lib.actions import Key
+from castervoice.lib.terminal import TerminalCommand
 from castervoice.lib.dfplus.state.short import R
 from castervoice.lib.dfplus.additions import IntegerRefST
-
 from castervoice.lib.dfplus.merge.mergepair import MergeInf
-from castervoice.lib.ccr import *
-from castervoice.lib.ccr.recording import again, bringme, alias
-from castervoice.lib.ccr.recording import history
-from castervoice.lib.dev import dev
-from castervoice.lib.dfplus.hint.nodes import css
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
-from castervoice.lib.dfplus.merge import gfilter
 
 if not globals().has_key('profile_switch_occurred'):
     # Load user rules

--- a/castervoice/asynch/_hmc.py
+++ b/castervoice/asynch/_hmc.py
@@ -1,14 +1,5 @@
-from dragonfly import (Function, Grammar, AppContext)
-
+from castervoice.lib.imports import *
 from castervoice.asynch.hmc import h_launch
-from castervoice.lib import control
-from castervoice.lib import settings, utilities
-from castervoice.lib.dfplus.additions import IntegerRefST
-from castervoice.lib.dfplus.merge import gfilter
-from castervoice.lib.dfplus.merge.mergerule import MergeRule
-from castervoice.lib.dfplus.state.actions import AsynchronousAction
-from castervoice.lib.dfplus.state.short import R, L, S
-from castervoice.lib.context import AppContext
 
 _NEXUS = control.nexus()
 
@@ -58,103 +49,50 @@ def hmc_settings_complete(nexus):
 class HMCRule(MergeRule):
     mapping = {
         "kill homunculus":
-            R(Function(kill, nexus=_NEXUS), rdescript="Kill Helper Window"),
+            R(Function(kill, nexus=_NEXUS)),
         "complete":
-            R(Function(complete, nexus=_NEXUS), rdescript="Complete Input")
+            R(Function(complete, nexus=_NEXUS))
     }
-
-
-grammar = Grammar("hmc", context=AppContext(title=settings.HOMUNCULUS_VERSION))
-r1 = HMCRule()
-gfilter.run_on(r1)
-grammar.add_rule(r1)
-if settings.SETTINGS["feature_rules"]["hmc"]:
-    grammar.load()
-
 
 class HMCHistoryRule(MergeRule):
     mapping = {
         # specific to macro recorder
         "check <n>":
-            R(Function(hmc_checkbox, nexus=_NEXUS), rdescript="Check Checkbox"),
+            R(Function(hmc_checkbox, nexus=_NEXUS)),
         "check from <n> to <n2>":
-            R(Function(hmc_recording_check_range, nexus=_NEXUS), rdescript="Check Range"),
+            R(Function(hmc_recording_check_range, nexus=_NEXUS)),
         "exclude <n>":
-            R(Function(hmc_recording_exclude, nexus=_NEXUS),
-              rdescript="Uncheck Checkbox"),
+            R(Function(hmc_recording_exclude, nexus=_NEXUS)),
         "[make] repeatable":
-            R(Function(hmc_recording_repeatable, nexus=_NEXUS),
-              rdescript="Make Macro Repeatable")
+            R(Function(hmc_recording_repeatable, nexus=_NEXUS))
     }
     extras = [
         IntegerRefST("n", 1, 25),
         IntegerRefST("n2", 1, 25),
     ]
 
-
-grammar_history = Grammar(
-    "hmc history", context=AppContext(title=settings.HMC_TITLE_RECORDING))
-r2 = HMCHistoryRule()
-gfilter.run_on(r2)
-grammar_history.add_rule(r2)
-if settings.SETTINGS["feature_rules"]["hmc"]:
-    grammar_history.load()
-
-
 class HMCDirectoryRule(MergeRule):
     mapping = {
         # specific to directory browser
         "browse":
-            R(Function(hmc_directory_browse, nexus=_NEXUS), rdescript="Browse Computer")
+            R(Function(hmc_directory_browse, nexus=_NEXUS))
     }
-
-
-grammar_directory = Grammar(
-    "hmc directory", context=AppContext(title=settings.HMC_TITLE_DIRECTORY))
-r3 = HMCDirectoryRule()
-gfilter.run_on(r3)
-grammar_directory.add_rule(r3)
-if settings.SETTINGS["feature_rules"]["hmc"]:
-    grammar_directory.load()
-
 
 class HMCConfirmRule(MergeRule):
     mapping = {
         # specific to confirm
         "confirm":
-            R(Function(hmc_confirm, value=True, nexus=_NEXUS),
-              rdescript="HMC: Confirm Action"),
+            R(Function(hmc_confirm, value=True, nexus=_NEXUS)),
         "disconfirm":
             R(Function(hmc_confirm, value=False, nexus=_NEXUS),
-              rspec="hmc_cancel",
-              rdescript="HMC: Cancel Action")
+              rspec="hmc_cancel")
     }
-
-
-grammar_confirm = Grammar(
-    "hmc confirm", context=AppContext(title=settings.HMC_TITLE_CONFIRM))
-r4 = HMCConfirmRule()
-gfilter.run_on(r4)
-grammar_confirm.add_rule(r4)
-if settings.SETTINGS["feature_rules"]["hmc"]:
-    grammar_confirm.load()
-
 
 class HMCSettingsRule(MergeRule):
     mapping = {
-        "kill homunculus": R(Function(kill), rdescript="Kill Settings Window"),
-        "complete": R(Function(hmc_settings_complete), rdescript="Complete Input"),
+        "kill homunculus": R(Function(kill)),
+        "complete": R(Function(hmc_settings_complete)),
     }
-
-
-grammar_settings = Grammar(
-    "hmc settings", context=AppContext(title=settings.SETTINGS_WINDOW_TITLE))
-r5 = HMCSettingsRule()
-gfilter.run_on(r5)
-grammar_settings.add_rule(r5)
-if settings.SETTINGS["feature_rules"]["hmc"]:
-    grammar_settings.load()
-
 
 def receive_settings(data):
     settings.SETTINGS = data
@@ -176,17 +114,16 @@ def settings_window(nexus):
 class LaunchRule(MergeRule):
     mapping = {
         "launch settings window":
-            R(Function(settings_window, nexus=_NEXUS),
-              rdescript="Launch Settings Window"),
+            R(Function(settings_window, nexus=_NEXUS)),
     }
 
-
-grammarw = Grammar("Caster Windows")
-r6 = LaunchRule()
-gfilter.run_on(r6)
-grammarw.add_rule(r6)
 if settings.SETTINGS["feature_rules"]["hmc"]:
-    grammarw.load()
+    control.non_ccr_app_rule(HMCRule(), AppContext(title=settings.HOMUNCULUS_VERSION), rdp=False)
+    control.non_ccr_app_rule(HMCHistoryRule(), AppContext(title=settings.HMC_TITLE_RECORDING), rdp=False)
+    control.non_ccr_app_rule(HMCDirectoryRule(), AppContext(title=settings.HMC_TITLE_DIRECTORY), rdp=False)
+    control.non_ccr_app_rule(HMCConfirmRule(), AppContext(title=settings.HMC_TITLE_CONFIRM), rdp=False)
+    control.non_ccr_app_rule(HMCSettingsRule(), AppContext(title=settings.SETTINGS_WINDOW_TITLE), rdp=False)
+    control.non_ccr_app_rule(LaunchRule(), context=None, rdp=False)
 
 if not settings.SETTINGS["feature_rules"]["hmc"]:
     print("WARNING: Tk Window controls have been disabled -- this is not advised!")

--- a/castervoice/asynch/sikuli/sikuli.py
+++ b/castervoice/asynch/sikuli/sikuli.py
@@ -1,13 +1,5 @@
-from subprocess import Popen
+from castervoice.lib.imports import *
 import xmlrpclib
-
-from dragonfly import (Grammar, MappingRule, Function)
-
-from castervoice.lib import control
-from castervoice.lib import settings, utilities
-from castervoice.lib.dfplus.merge import gfilter
-from castervoice.lib.dfplus.merge.mergerule import MergeRule
-from castervoice.lib.dfplus.state.short import R
 
 grammar = None
 custom_rule = None
@@ -27,12 +19,12 @@ def launch_server():
     else:
         command = [] if settings.SETTINGS["sikuli"]["version"] == "1.1.3" else ["java", "-jar"]
         command.extend([
-            settings.SETTINGS["paths"]["SIKULI_RUNNER"], 
+            settings.SETTINGS["paths"]["SIKULI_RUNNER"],
             "-r", settings.SETTINGS["paths"]["SIKULI_SERVER_PATH"],
             "--args", settings.SETTINGS["paths"]["SIKULI_SCRIPTS_PATH"]
         ])
         Popen(command)
-#     
+#
 #     Popen([
 #         settings.SETTINGS["paths"]["SIKULI_COMPATIBLE_JAVA_EXE_PATH"], "-jar",
 #         settings.SETTINGS["paths"]["SIKULI_SCRIPTS_JAR_PATH"], "-r",
@@ -106,14 +98,11 @@ class SikuliControlCommandsRule(MergeRule):
     pronunciation = "sikuli"
 
     mapping = {
-        "launch sick IDE":       R(Function(launch_IDE), rdescript="Sikulix: Launch Sikulix IDE"),
-        "launch sick server":    R(Function(bootstrap_start_server_proxy), rdescript="Sikulix: Launch Sikulix Server"),
-        "terminate sick server": R(Function(terminate_sick_command), rdescript="Sikulix: Terminate Sikulix server"),
+        "launch sick IDE":       R(Function(launch_IDE)),
+        "launch sick server":    R(Function(bootstrap_start_server_proxy)),
+        "terminate sick server": R(Function(terminate_sick_command)),
     }
 
 if settings.SETTINGS["sikuli"]["enabled"]:
-    grammar = Grammar("sikuli")
-    rule = SikuliControlCommandsRule(name="sikuli control commands")
-    gfilter.run_on(rule)
-    grammar.add_rule(rule)
+    control.non_ccr_app_rule(SikuliControlCommandsRule(), context=None, rdp=False)
     bootstrap_start_server_proxy()

--- a/castervoice/lib/ccr/bash/bash.py
+++ b/castervoice/lib/ccr/bash/bash.py
@@ -93,4 +93,4 @@ class Bash(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Bash())
+control.global_rule(Bash())

--- a/castervoice/lib/ccr/core/alphabet.py
+++ b/castervoice/lib/ccr/core/alphabet.py
@@ -17,4 +17,4 @@ class Alphabet(MergeRule):
         "big": False,
     }
 
-control.nexus().merger.add_global_rule(Alphabet())
+control.global_rule(Alphabet())

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -328,4 +328,4 @@ class Navigation(MergeRule):
     }
 
 
-control.nexus().merger.add_global_rule(Navigation())
+control.global_rule(Navigation())

--- a/castervoice/lib/ccr/core/numbers.py
+++ b/castervoice/lib/ccr/core/numbers.py
@@ -17,4 +17,4 @@ class Numbers(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Numbers())
+control.global_rule(Numbers())

--- a/castervoice/lib/ccr/core/punctuation.py
+++ b/castervoice/lib/ccr/core/punctuation.py
@@ -99,4 +99,4 @@ class Punctuation(MergeRule):
         "long": "",
     }
 
-control.nexus().merger.add_global_rule(Punctuation())
+control.global_rule(Punctuation())

--- a/castervoice/lib/ccr/core/text_manipulation.py
+++ b/castervoice/lib/ccr/core/text_manipulation.py
@@ -155,7 +155,7 @@ class TextManipulation(MergeRule):
         # This can be changed in the function deal_with_up_down_directions
         # 'number_of_lines_to_search = zero' means you are searching only on the current line
 
-control.nexus().merger.add_global_rule(TextManipulation())
+control.global_rule(TextManipulation())
 
 
 

--- a/castervoice/lib/ccr/cpp/cpp.py
+++ b/castervoice/lib/ccr/cpp/cpp.py
@@ -126,4 +126,4 @@ class CPP(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(CPP())
+control.global_rule(CPP())

--- a/castervoice/lib/ccr/csharp/csharp.py
+++ b/castervoice/lib/ccr/csharp/csharp.py
@@ -122,4 +122,4 @@ class CSharp(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(CSharp())
+control.global_rule(CSharp())

--- a/castervoice/lib/ccr/dart/dart.py
+++ b/castervoice/lib/ccr/dart/dart.py
@@ -117,4 +117,4 @@ class Dart(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Dart())
+control.global_rule(Dart())

--- a/castervoice/lib/ccr/go/go.py
+++ b/castervoice/lib/ccr/go/go.py
@@ -88,4 +88,4 @@ class Go(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Go())
+control.global_rule(Go())

--- a/castervoice/lib/ccr/haxe/haxe.py
+++ b/castervoice/lib/ccr/haxe/haxe.py
@@ -113,4 +113,4 @@ class Haxe(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Haxe())
+control.global_rule(Haxe())

--- a/castervoice/lib/ccr/html/html.py
+++ b/castervoice/lib/ccr/html/html.py
@@ -293,4 +293,4 @@ class HTML(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(HTML())
+control.global_rule(HTML())

--- a/castervoice/lib/ccr/java/java.py
+++ b/castervoice/lib/ccr/java/java.py
@@ -153,4 +153,4 @@ class Java(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Java())
+control.global_rule(Java())

--- a/castervoice/lib/ccr/javascript/javascript.py
+++ b/castervoice/lib/ccr/javascript/javascript.py
@@ -127,4 +127,4 @@ class Javascript(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Javascript(ID=200))
+control.global_rule(Javascript(ID=200))

--- a/castervoice/lib/ccr/latex/latex.py
+++ b/castervoice/lib/ccr/latex/latex.py
@@ -180,4 +180,4 @@ class LaTeX(MergeRule):
     }
 
 
-control.nexus().merger.add_global_rule(LaTeX())
+control.global_rule(LaTeX())

--- a/castervoice/lib/ccr/markdown/markdown.py
+++ b/castervoice/lib/ccr/markdown/markdown.py
@@ -48,4 +48,4 @@ class Markdown(MergeRule):
     }
 
 
-control.nexus().merger.add_global_rule(Markdown())
+control.global_rule(Markdown())

--- a/castervoice/lib/ccr/matlab/matlab.py
+++ b/castervoice/lib/ccr/matlab/matlab.py
@@ -92,4 +92,4 @@ class Matlab(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Matlab())
+control.global_rule(Matlab())

--- a/castervoice/lib/ccr/prolog/prolog.py
+++ b/castervoice/lib/ccr/prolog/prolog.py
@@ -35,4 +35,4 @@ class Prolog(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Prolog())
+control.global_rule(Prolog())

--- a/castervoice/lib/ccr/python/python.py
+++ b/castervoice/lib/ccr/python/python.py
@@ -171,4 +171,4 @@ class Python(MergeRule):
     defaults = {"unary_meth": "", "binary_meth": "", "exception": ""}
 
 
-control.nexus().merger.add_global_rule(Python(ID=100))
+control.global_rule(Python(ID=100))

--- a/castervoice/lib/ccr/r/r.py
+++ b/castervoice/lib/ccr/r/r.py
@@ -169,4 +169,4 @@ class Rlang(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(Rlang())
+control.global_rule(Rlang())

--- a/castervoice/lib/ccr/recording/again.py
+++ b/castervoice/lib/ccr/recording/again.py
@@ -3,16 +3,7 @@ Created on Sep 6, 2015
 
 @author: synkarius
 '''
-
-from dragonfly.actions.action_function import Function
-from dragonfly.actions.action_playback import Playback
-
-from castervoice.lib import settings
-from castervoice.lib.dfplus.additions import IntegerRefST
-from castervoice.lib.dfplus.state.actions import AsynchronousAction
-from castervoice.lib.dfplus.state.short import L, S, R
-from castervoice.lib.dfplus.merge.mergerule import MergeRule
-
+from castervoice.lib.imports import *
 
 class Again(MergeRule):
     def __init__(self, nexus):
@@ -52,3 +43,8 @@ class Again(MergeRule):
             time_in_seconds=0.2,
             repetitions=int(n),
             blocking=False).execute()
+
+_NEXUS = control.nexus()
+
+if settings.SETTINGS["feature_rules"]["again"]:
+    control.non_ccr_app_rule(Again(_NEXUS), context=None, rdp=False)

--- a/castervoice/lib/ccr/recording/alias.py
+++ b/castervoice/lib/ccr/recording/alias.py
@@ -1,16 +1,7 @@
-from dragonfly.actions.action_function import Function
-
+from castervoice.lib.imports import *
 from castervoice.asynch.hmc import h_launch
-from castervoice.lib import context, utilities, settings
-from castervoice.lib import control
-from castervoice.lib.actions import Text
-from castervoice.lib.dfplus.merge.selfmodrule import SelfModifyingRule
-from castervoice.lib.dfplus.state.actions import AsynchronousAction
-from castervoice.lib.dfplus.state.actions2 import NullAction
-from castervoice.lib.dfplus.state.short import R, L, S
 
 _NEXUS = control.nexus()
-
 
 def read_highlighted(max_tries):
     for i in range(0, max_tries):
@@ -97,6 +88,10 @@ class ChainAlias(AliasRule):
             rdescript="Delete Aliases")
         self.reset(mapping)
 
-if settings.SETTINGS["feature_rules"]["chainalias"]:
-    control.nexus().merger.add_selfmodrule(ChainAlias(_NEXUS))
+_NEXUS = control.nexus()
 
+if settings.SETTINGS["feature_rules"]["alias"]:
+    control.non_ccr_app_rule(Alias(_NEXUS), context=None, rdp=False)
+
+if settings.SETTINGS["feature_rules"]["chainalias"]:
+    control.selfmod_rule(ChainAlias(_NEXUS))

--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -126,4 +126,6 @@ class BringRule(SelfModifyingRule):
 
     defaults = {'desired_item': ('', ""), 'launch': 'program', 'key': ''}
 
-control.non_ccr_app_rule(BringRule(), context=None, rdp=False)
+bring_rule = BringRule()
+
+control.non_ccr_app_rule(bring_rule, context=None, rdp=False)

--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -1,16 +1,4 @@
-import os
-import shutil
-import threading
-import subprocess
-import time
-import shlex
-# import dragonfly
-from dragonfly import Choice, Function, Dictation
-
-from castervoice.lib import control, context, utilities, settings
-from castervoice.lib.actions import Text, Key
-from castervoice.lib.dfplus.merge.selfmodrule import SelfModifyingRule
-from castervoice.lib.dfplus.state.short import R
+from castervoice.lib.imports import *
 
 if os.path.isfile(settings.SETTINGS["paths"]["BRINGME_PATH"]) is False:
     bringme_default = settings.SETTINGS["paths"]["BRINGME_DEFAULTS_PATH"]
@@ -30,7 +18,7 @@ def refresh():
 # module functions
 def bring_it(desired_item):
     '''
-    Currently simply invoke os.startfile. New thread keeps Dragon from crashing. 
+    Currently simply invoke os.startfile. New thread keeps Dragon from crashing.
     '''
     item, item_type = desired_item
     if item_type == "website":
@@ -115,18 +103,13 @@ class BringRule(SelfModifyingRule):
 
     mapping = {
         "bring me <desired_item>":
-            R(Function(bring_it),
-              rdescript="BringMe: Launch preconfigured program, folder or website"),
+            R(Function(bring_it)),
         "<launch> to bring me as <key>":
-            R(Function(bring_add, extra={"launch", "key"}),
-              rdescript="BringMe: Add program, folder or website to the bring me list"),
+            R(Function(bring_add, extra={"launch", "key"})),
         "remove <key> from bring me":
-            R(Function(bring_remove, extra="key"),
-              rdescript="BringMe: Remove program, folder or website from the bring me list"
-              ),
+            R(Function(bring_remove, extra="key")),
         "restore bring me defaults":
-            R(Function(bring_restore),
-              rdescript="BringMe: Delete bring me list and put defaults in its place"),
+            R(Function(bring_restore)),
     }
 
     extras = [
@@ -143,7 +126,4 @@ class BringRule(SelfModifyingRule):
 
     defaults = {'desired_item': ('', ""), 'launch': 'program', 'key': ''}
 
-
-bring_rule = BringRule()
-# Does not work
-# control.nexus().merger.add_selfmodrule(bring_rule)
+control.non_ccr_app_rule(BringRule(), context=None, rdp=False)

--- a/castervoice/lib/ccr/rust/rust.py
+++ b/castervoice/lib/ccr/rust/rust.py
@@ -143,4 +143,4 @@ class Rust(MergeRule):
     defaults = {"bits": "32", "signed": "i", "mutability": "", "a": "i", "b": "j", "n": 1}
 
 
-control.nexus().merger.add_global_rule(Rust())
+control.global_rule(Rust())

--- a/castervoice/lib/ccr/sql/sql.py
+++ b/castervoice/lib/ccr/sql/sql.py
@@ -83,4 +83,4 @@ class SQL(MergeRule):
     defaults = {}
 
 
-control.nexus().merger.add_global_rule(SQL())
+control.global_rule(SQL())

--- a/castervoice/lib/ccr/vhdl/vhdl.py
+++ b/castervoice/lib/ccr/vhdl/vhdl.py
@@ -163,4 +163,4 @@ class VHDL(MergeRule):
     ]
     defaults = {}
 
-control.nexus().merger.add_global_rule(VHDL())
+control.global_rule(VHDL())

--- a/castervoice/lib/ccr/voice_dev_commands/voice_dev_commands.py
+++ b/castervoice/lib/ccr/voice_dev_commands/voice_dev_commands.py
@@ -202,4 +202,4 @@ class VoiceDevCommands(MergeRule):
     ]
     defaults = {"spec": "", "dict": "", "text": "", "mouse_button": ""}
 
-control.nexus().merger.add_global_rule(VoiceDevCommands())
+control.global_rule(VoiceDevCommands())

--- a/castervoice/lib/imports.py
+++ b/castervoice/lib/imports.py
@@ -20,10 +20,11 @@ from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.merge.selfmodrule import SelfModifyingRule
 
 from castervoice.lib.dfplus.state.actions import AsynchronousAction, ContextSeeker
-from castervoice.lib.dfplus.state.actions2 import UntilCancelled
+from castervoice.lib.dfplus.state.actions2 import UntilCancelled, NullAction, BoxAction, ConfirmAction
 from castervoice.lib.dfplus.state.short import L, S, R
 
 from castervoice.lib.ccr.standard import SymbolSpecs
 from castervoice.lib.ccr.core.punctuation import double_text_punc_dict, text_punc_dict
 
 import os, sys, re, copy, itertools, time
+import shutil, threading, subprocess, shlex

--- a/castervoice/lib/imports.py
+++ b/castervoice/lib/imports.py
@@ -28,3 +28,4 @@ from castervoice.lib.ccr.core.punctuation import double_text_punc_dict, text_pun
 
 import os, sys, re, copy, itertools, time
 import shutil, threading, subprocess, shlex
+from subprocess import Popen


### PR DESCRIPTION
Trying to do changes which touch a lot of files all in one go so that it doesn't cause too much disruption. Mainly just removing the last manual grammar loadings and removing direct calls to the CCRMerger.

I have also begun the task of moving unnecessary stuff out of `_caster.py`, moving the loading of self modifying rules into their respective files to enable easier modification in the future. 