### PR TITLE
Improve rule naming in rdescripts

### DIFF
--- a/castervoice/lib/dfplus/merge/mergerule.py
+++ b/castervoice/lib/dfplus/merge/mergerule.py
@@ -75,17 +75,21 @@ class MergeRule(MappingRule):
             return False
         return self.ID == other.ID
 
-    def format_actions(self):
-        def create_rdescript(command, raction):
+    def create_rdescript(self, command, raction):
+            rule_name = self.name
+            for unnecessary in ["Non", "Rule", "Ccr", "CCR"]:
+                rule_name = rule_name.replace(unnecessary, "")
             extras = ""
             named_extras = re.findall(r"<(.*?)>", command)
             if named_extras:
                 extras = ", %(" + ")s, %(".join(named_extras) + ")s"
-            return "%s: %s%s" % (self.name, command, extras)
+            return "%s: %s%s" % (rule_name, command, extras)
+
+    def format_actions(self):
         for command, action in self.mapping.items():
             #pylint: disable=no-member
             if hasattr(action, "rdescript") and action.rdescript is None:
-                self.mapping[command].rdescript = create_rdescript(command, action)
+                self.mapping[command].rdescript = self.create_rdescript(command, action)
 
 
     ''' "copy" getters used for safe merging;


### PR DESCRIPTION
So that instead of e.g. "VSCodeNonCcrRule: command" it will just print "VSCode: command" 