### PR TITLE
Fixed Selfmodrule filter bug

### DIFF
--- a/castervoice/lib/ccr/recording/alias.py
+++ b/castervoice/lib/ccr/recording/alias.py
@@ -91,7 +91,7 @@ class ChainAlias(AliasRule):
 _NEXUS = control.nexus()
 
 if settings.SETTINGS["feature_rules"]["alias"]:
-    control.non_ccr_app_rule(Alias(_NEXUS), context=None, rdp=False)
+    control.non_ccr_app_rule(Alias(_NEXUS), context=None, rdp=False, filter=False)
 
 if settings.SETTINGS["feature_rules"]["chainalias"]:
     control.selfmod_rule(ChainAlias(_NEXUS))

--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -128,4 +128,4 @@ class BringRule(SelfModifyingRule):
 
 bring_rule = BringRule()
 
-control.non_ccr_app_rule(bring_rule, context=None, rdp=False)
+control.non_ccr_app_rule(bring_rule, context=None, rdp=False, filter=False)

--- a/castervoice/lib/control.py
+++ b/castervoice/lib/control.py
@@ -17,7 +17,7 @@ def nexus():
 Commands for easily loading different types of rules, e.g.:
 control.non_ccr_app_rule(FirefoxRule(), AppContext("firefox"))
 '''
-def non_ccr_app_rule(rule, context=None, name=None, rdp=True):
+def non_ccr_app_rule(rule, context=None, name=None, rdp=True, filter=True):
     if settings.SETTINGS["miscellaneous"]["rdp_mode"] and rdp:
         nexus().merger.add_global_rule(rule)
     else:
@@ -25,7 +25,7 @@ def non_ccr_app_rule(rule, context=None, name=None, rdp=True):
             context = rule.get_context()
         grammar_name = name if name else str(rule)
         grammar = Grammar(grammar_name, context=context)
-        gfilter.run_on(rule)
+        if filter: gfilter.run_on(rule)
         grammar.add_rule(rule)
         grammar.load()
 


### PR DESCRIPTION
To recreate:
1. Add a filter rule in words.txt e.g. "tango -> trap"
2. Add an alias with the same name e.g. "Alias tango"
3. restart

Produces: 
```
  File "C:\Users\Mike\Documents\GitHub\casterfork\castervoice\lib\dfplus\merge\gfilter.py", line 221, in spec_override_from_config
    rule._mcontext, rule._mwith)
TypeError: __init__() takes exactly 2 arguments (11 given)
-- skip unchanged wrong grammar file: C:\Users\Mike\Documents\GitHub\casterfork\_caster.py
-- skip unchanged wrong grammar file: C:\Users\Mike\Documents\GitHub\casterfork\_caster.py
```
I assume this has pretty much been the case since forever as the chances of finding it are fairly small.

Fixed for the moment by not running filters on self modifying rules. It doesn't really make sense to filter them anyway as they are set by the user, and filters are mainly used for modifying caster defaults.