### PR TITLE
Classic install: Enhancements to check dependencies for required versions and missing dependencies.

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -8,24 +8,6 @@ import os, time, sys
 import logging
 logging.basicConfig()
 
-
-def version_minimum():
-    try:
-        import pkg_resources
-        version = "0.15.0"  # Minimum Version of Dragonfly2 need for Caster
-        pkg_resources.require("dragonfly2 >= %s" % (version))
-    except Exception:  # pylint: disable=broad-except
-        pass
-        print("\nCaster will not start! \
-            \nCaster: Requires at least Dragonfly version %s\
-            \nUpdate Dragonfly 'pip install --upgrade dragonfly2' from cmd\
-            \n\nThis window will close in 30 seconds" % (version))
-        time.sleep(30)
-        os._exit(1)
-
-
-version_minimum()
-
 import time, socket, os
 from dragonfly import (Function, Grammar, Playback, Dictation, Choice, Pause, RunCommand)
 from castervoice.lib.ccr.standard import SymbolSpecs

--- a/_caster.py
+++ b/_caster.py
@@ -19,7 +19,7 @@ def version_minimum():
         print("\nCaster will not start! \
             \nCaster: Requires at least Dragonfly version %s\
             \nUpdate Dragonfly 'pip install --upgrade dragonfly2' from cmd\
-            \n\nThis window will close in 60 seconds" % (version))
+            \n\nThis window will close in 30 seconds" % (version))
         time.sleep(30)
         os._exit(1)
 

--- a/_caster.py
+++ b/_caster.py
@@ -4,7 +4,7 @@ main Caster module
 Created on Jun 29, 2014
 '''
 
-import os
+import os, time, sys
 import logging
 logging.basicConfig()
 
@@ -12,10 +12,16 @@ logging.basicConfig()
 def version_minimum():
     try:
         import pkg_resources
-        version = "0.15.0"  # Version needs to be manually updated Caster requires a certain version of Dragonfly
+        version = "0.15.0"  # Minimum Version of Dragonfly2 need for Caster
         pkg_resources.require("dragonfly2 >= %s" % (version))
     except Exception:  # pylint: disable=broad-except
-        print("\nCaster: Requires at least dragonfly2 version %s\n" % (version))
+        pass
+        print("\nCaster will not start! \
+            \nCaster: Requires at least Dragonfly version %s\
+            \nUpdate Dragonfly 'pip install --upgrade dragonfly2' from cmd\
+            \n\nThis window will close in 60 seconds" % (version))
+        time.sleep(30)
+        os._exit(1)
 
 
 version_minimum()

--- a/_caster.py
+++ b/_caster.py
@@ -36,6 +36,7 @@ from castervoice.lib import utilities  # requires settings
 if settings.WSR:
     _wait_for_wsr_activation()
     SymbolSpecs.set_cancel_word("escape")
+from castervoice.lib.ctrl.dependencies import pip_path
 from castervoice.lib import control
 _NEXUS = control.nexus()
 from castervoice.lib import navigation
@@ -62,78 +63,6 @@ if not globals().has_key('profile_switch_occurred'):
     _NEXUS.merger.merge(MergeInf.BOOT)
 
 
-# Checks if install is classic or PIP of caster
-def installtype():
-    directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "castervoice")
-    if os.path.isdir(directory):
-        return "classic"
-    else:
-        return "pip"
-
-
-def internetcheck(host="1.1.1.1", port=53, timeout=3):
-    """
-    Checks for network connection via DNS resolution.
-    :param host: CloudFire DNS
-    :param port: 53/tcp
-    :param timeout: An integer
-    :return: True or False
-    """
-    try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
-        return True
-    except Exception as error:
-        print(error.message)
-        return False
-
-
-# Find the pip.exe script for Python 2.7. Fallback on pip.exe.
-PIP_PATH = "pip.exe"
-python_scripts = os.path.join("Python27", "Scripts")
-for path in os.environ["PATH"].split(";"):
-    pip = os.path.join(path, "pip.exe")
-    if path.endswith(python_scripts) and os.path.isfile(pip):
-        PIP_PATH = pip
-        break
-
-
-class DependencyCheck(TerminalCommand):
-    trusted = True  # Command will execute silently without ConfirmAction
-    synchronous = True
-
-    # pylint: disable=method-hidden
-    def process_command(self, proc):
-        update = False
-        for line in iter(proc.stdout.readline, b''):
-            if "INSTALLED" and "latest" in line:
-                update = True
-
-        return update
-
-
-class CasterCheck(DependencyCheck):
-    command = [PIP_PATH, "search", "castervoice"]
-
-    # pylint: disable=method-hidden
-    def process_command(self, proc):
-        if DependencyCheck.process_command(self, proc):
-            print("Caster: Caster is up-to-date")
-        else:
-            print("Caster: Say 'Update Caster' to update.")
-
-
-class DragonflyCheck(DependencyCheck):
-    command = [PIP_PATH, "search", "dragonfly2"]
-
-    # pylint: disable=method-hidden
-    def process_command(self, proc):
-        if DependencyCheck.process_command(self, proc):
-            print("Caster: Dragonfly is up-to-date")
-        else:
-            print("Caster: Say 'Update Dragonfly' to update.")
-
-
 class DependencyUpdate(RunCommand):
     synchronous = True
 
@@ -141,23 +70,10 @@ class DependencyUpdate(RunCommand):
     def process_command(self, proc):
         # Process the output from the command.
         RunCommand.process_command(self, proc)
-
-        # Only reboot dragon if the command was successful and there is an
-        # internet connection; 'pip install ...' may exit successfully even
-        # if there were connection errors.
-        if proc.wait() == 0 and internetcheck():
+        # Only reboot dragon if the command was successful and online_mode is true
+        # 'pip install ...' may exit successfully even if there were connection errors.
+        if proc.wait() == 0 and settings.SETTINGS["miscellaneous"]["online_mode"]:
             Playback([(["reboot", "dragon"], 0.0)]).execute()
-
-
-if settings.SETTINGS["miscellaneous"]["online_mode"]:
-    if internetcheck():
-        if installtype() is "pip":
-            CasterCheck().execute()
-        DragonflyCheck().execute()
-    else:
-        print("\nCaster: Network off-line check network connection\n")
-else:
-    print("\nCaster: Off-line mode is enabled\n")
 
 
 def change_monitor():
@@ -185,9 +101,9 @@ class MainRule(MergeRule):
     mapping = {
         # update management
         "update caster":
-            R(DependencyUpdate([PIP_PATH, "install", "--upgrade", "castervoice"])),
+            R(DependencyUpdate([pip_path, "install", "--upgrade", "castervoice"])),
         "update dragonfly":
-            R(DependencyUpdate([PIP_PATH, "install", "--upgrade", "dragonfly2"])),
+            R(DependencyUpdate([pip_path, "install", "--upgrade", "dragonfly2"])),
 
         # hardware management
         "volume <volume_mode> [<n>]":

--- a/_caster.py
+++ b/_caster.py
@@ -36,7 +36,7 @@ from castervoice.lib import utilities  # requires settings
 if settings.WSR:
     _wait_for_wsr_activation()
     SymbolSpecs.set_cancel_word("escape")
-from castervoice.lib.ctrl.dependencies import pip_path
+from castervoice.lib.ctrl.dependencies import pip_path, update
 from castervoice.lib import control
 _NEXUS = control.nexus()
 from castervoice.lib import navigation
@@ -72,7 +72,7 @@ class DependencyUpdate(RunCommand):
         RunCommand.process_command(self, proc)
         # Only reboot dragon if the command was successful and online_mode is true
         # 'pip install ...' may exit successfully even if there were connection errors.
-        if proc.wait() == 0 and settings.SETTINGS["miscellaneous"]["online_mode"]:
+        if proc.wait() == 0 and update:
             Playback([(["reboot", "dragon"], 0.0)]).execute()
 
 

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -102,7 +102,7 @@ def dep_min_version():
     # A GitHub Issue URL needed to explain the change to version specific '==' dependency.
     upgradelist = []
     listdependency = ([
-        ["dragonfly2", ">=", "0.14.1", None],
+        ["dragonfly2", ">=", "0.13.0", None],
     ])
     for dep in listdependency:
         package = dep[0]

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -68,13 +68,14 @@ def dependency_check(command=None):
                              startupinfo=startupinfo)
         out = p.communicate('')
         for line in out:
-            if "INSTALLED" and "(latest)":
+            if "INSTALLED" and "latest" in line:
                 print("Caster: {0} is up-to-date".format(command))
                 update = False
                 break
             else:
                 print("Caster: Say 'Update {0}' to update.".format(command))
                 update = True
+                break
     except Exception as e:
         print("Exception from starting subprocess {0}: " "{1}".format(com, e))
 

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -3,50 +3,139 @@ Created on Oct 7, 2015
 
 @author: synkarius
 '''
+
+import os, socket, time, pkg_resources, subprocess
+from pkg_resources import VersionConflict, DistributionNotFound
+from subprocess import Popen
 from castervoice.lib import settings
-import time
+
+pip_path = None
+update = None
 
 
-def version_minimum():
+def findpip():
+    # Find the pip.exe script for Python 2.7. Fallback on pip.exe.
+    global pip_path
+    python_scripts = os.path.join("Python27", "Scripts")
+    for path in os.environ["PATH"].split(";"):
+        pip = os.path.join(path, "pip.exe")
+        if path.endswith(python_scripts) and os.path.isfile(pip):
+            pip_path = pip
+            break
+
+
+# Checks if install is Classic or PIP of caster
+def installtype():
     try:
-        import pkg_resources
-        version = "0.13.0"  # Minimum Version of Dragonfly2 need for Caster
-        pkg_resources.require("dragonfly2 >= %s" % (version))
-    except Exception:  # pylint: disable=broad-except
+        pkg_resources.require("castervoice")
+    except VersionConflict:
         pass
-        print("\nCaster: Requires at least Dragonfly version %s" \
-            "\n Update Dragonfly 'pip install --upgrade dragonfly2' from cmd.\n" % (version))
-        time.sleep(15)
+    except DistributionNotFound:
+        return "classic"
+    return "pip"
 
 
-version_minimum()
+def internetcheck(host="1.1.1.1", port=53, timeout=3):
+    """
+    Checks for network connection via DNS resolution.
+    :param host: CloudFire DNS
+    :param port: 53/tcp
+    :param timeout: An integer
+    :return: True or False
+    """
+    try:
+        socket.setdefaulttimeout(timeout)
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
+        return True
+    except Exception as error:
+        print(error.message)
+        return False
+
+
+def DependencyCheck(command=None):
+    com = [pip_path, "search", command]
+    startupinfo = None
+    # print com
+    global update
+    try:
+        if os.name == 'nt':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+        p = subprocess.Popen(com,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             stdin=subprocess.PIPE,
+                             startupinfo=startupinfo)
+        out = p.communicate('')
+        for line in out:
+            if "INSTALLED" and "(latest)":
+                print("Caster: {0} is up-to-date".format(command))
+                update = False
+                break
+            else:
+                print("Caster: Say 'Update {0}' to update.".format(command))
+                update = True
+    except Exception as e:
+        print("Exception from starting subprocess {0}: " "{1}".format(com, e))
+
+
+def DepMissing():
+    with open('D:\\Backup\\Library\\Documents\\Caster\\requirements.txt') as f:
+        requirements = f.read().splitlines()
+    for dep in requirements:
+        try:
+            pkg_resources.require("{}".format(dep))
+        except VersionConflict:
+            pass
+        except DistributionNotFound as e:
+            print("\n Caster: A Dependency is missing 'pip install {0}'".format(e.req))
+            time.sleep(15)
+
+
+def DepMinVersion():
+    # Dependencies needs to be manually resolved if Caster requires a certain version of dependency
+    # Restart Dragon between tests so pkg_resources.require can find packages
+    # DepMinVersion Assumes only one package will have "=="
+    upgradelist = []
+    listdependency = ([
+        ["dragonfly2", ">=", "0.13.0", None],
+    ])
+    for dep in listdependency:
+        package = dep[0]
+        operator = dep[1]
+        version = dep[2]
+        url = dep[3]
+        try:
+            pkg_resources.require('{0} {1} {2}'.format(package, operator, version))
+        except VersionConflict as e:
+            if operator is ">=":
+                upgradelist.append('{0}'.format(package))
+            if operator is "==":
+                print("\nCaster: Requires an exact version of dependencies")
+                print("Install the exact version: 'pip install {0}'".format(e.req))
+    if not upgradelist:
+        pass
+    else:
+        pippackages = (' '.join(map(str, upgradelist)))
+        print(
+            "\nCaster: Requires updated version of dependencies.\n Update With: 'pip install --upgrade {0}' \n"
+            .format(pippackages))
 
 
 class DependencyMan:
     def __init__(self):
-        with open('D:\\Backup\\Library\\Documents\\Caster\\requirements.txt') as f:
-            requirements = f.read().splitlines()
-        self.list = requirements
-        warnings = 0
-        for dep in self.list:
-            is_optional = dep[0] == "win32ui"
-            try:
-                exec ("import " + dep[0])
-            except ImportError:
-                if not dep[0] in settings.SETTINGS["one time warnings"]:
-                    warnings += 1
-                    settings.SETTINGS["one time warnings"][dep[0]] = True
-
-                    urgency = "You can get it at " if is_optional else "If you wish to use those features, you can get it at "
-                    print("\n" + dep[0] + " is required for ", dep[2],
-                          " features. " + urgency + dep[3] + "\n")
+        install = installtype()
+        findpip()
+        if install is "classic":
+            DepMinVersion()
+            DepMissing()
+        if settings.SETTINGS["miscellaneous"]["online_mode"]:
+            if internetcheck():
+                if install is "pip":
+                    DependencyCheck(command="castervoice")
+                DependencyCheck(command="dragonfly2")
             else:
-                name = dep[0] if not is_optional else dep[1]
-                exec ("self." + name.upper() + "=True")
-        if warnings > 0:
-            settings.save_config()
-
-    NATLINK = False
-    PIL = False
-    PYWIN32 = False
-    WX = False
+                print("\nCaster: Network off-line check network connection\n")
+        else:
+            print("\nCaster: Off-line mode is enabled\n")

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -10,7 +10,7 @@ import time
 def version_minimum():
     try:
         import pkg_resources
-        version = "0.15.0"  # Minimum Version of Dragonfly2 need for Caster
+        version = "0.13.0"  # Minimum Version of Dragonfly2 need for Caster
         pkg_resources.require("dragonfly2 >= %s" % (version))
     except Exception:  # pylint: disable=broad-except
         pass
@@ -24,27 +24,24 @@ version_minimum()
 
 class DependencyMan:
     def __init__(self):
-
-        self.list = [
-            ("PIL", None, ["Legion"], "https://pypi.python.org/pypi/Pillow"),
-            #("wx", None, ["Settings Window"], "http://www.wxpython.org"),
-            ("win32ui", "pywin32", ["very many essential"],
-             "http://sourceforge.net/projects/pywin32")
-        ]
+        with open('D:\\Backup\\Library\\Documents\\Caster\\requirements.txt') as f:
+            requirements = f.read().splitlines()
+        self.list = requirements
         warnings = 0
         for dep in self.list:
-            is_win32ui = dep[0] == "win32ui"
+            is_optional = dep[0] == "win32ui"
             try:
                 exec ("import " + dep[0])
             except ImportError:
                 if not dep[0] in settings.SETTINGS["one time warnings"]:
                     warnings += 1
                     settings.SETTINGS["one time warnings"][dep[0]] = True
-                    urgency = "You can get it at " if is_win32ui else "If you wish to use those features, you can get it at "
+
+                    urgency = "You can get it at " if is_optional else "If you wish to use those features, you can get it at "
                     print("\n" + dep[0] + " is required for ", dep[2],
                           " features. " + urgency + dep[3] + "\n")
             else:
-                name = dep[0] if not is_win32ui else dep[1]
+                name = dep[0] if not is_optional else dep[1]
                 exec ("self." + name.upper() + "=True")
         if warnings > 0:
             settings.save_config()

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -4,6 +4,22 @@ Created on Oct 7, 2015
 @author: synkarius
 '''
 from castervoice.lib import settings
+import time
+
+
+def version_minimum():
+    try:
+        import pkg_resources
+        version = "0.15.0"  # Minimum Version of Dragonfly2 need for Caster
+        pkg_resources.require("dragonfly2 >= %s" % (version))
+    except Exception:  # pylint: disable=broad-except
+        pass
+        print("\nCaster: Requires at least Dragonfly version %s" \
+            "\n Update Dragonfly 'pip install --upgrade dragonfly2' from cmd.\n" % (version))
+        time.sleep(15)
+
+
+version_minimum()
 
 
 class DependencyMan:

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -13,7 +13,7 @@ pip_path = None
 update = None
 
 
-def findpip():
+def find_pip():
     # Find the pip.exe script for Python 2.7. Fallback on pip.exe.
     global pip_path
     python_scripts = os.path.join("Python27", "Scripts")
@@ -24,8 +24,8 @@ def findpip():
             break
 
 
-# Checks if install is Classic or PIP of caster
-def installtype():
+def install_type():
+    # Checks if install is Classic or PIP of caster
     try:
         pkg_resources.require("castervoice")
     except VersionConflict:
@@ -35,7 +35,7 @@ def installtype():
     return "pip"
 
 
-def internetcheck(host="1.1.1.1", port=53, timeout=3):
+def internet_check(host="1.1.1.1", port=53, timeout=3):
     """
     Checks for network connection via DNS resolution.
     :param host: CloudFire DNS
@@ -52,16 +52,15 @@ def internetcheck(host="1.1.1.1", port=53, timeout=3):
         return False
 
 
-def DependencyCheck(command=None):
+def dependency_check(command=None):
+    # For classic/pip: Check for updates Caster and Dragonfly
     com = [pip_path, "search", command]
     startupinfo = None
-    # print com
     global update
     try:
         if os.name == 'nt':
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-
         p = subprocess.Popen(com,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
@@ -80,7 +79,8 @@ def DependencyCheck(command=None):
         print("Exception from starting subprocess {0}: " "{1}".format(com, e))
 
 
-def DepMissing():
+def dep_missing():
+    # For classic: Parsesrequirements.txt checking for missing pip packages
     with open('D:\\Backup\\Library\\Documents\\Caster\\requirements.txt') as f:
         requirements = f.read().splitlines()
     for dep in requirements:
@@ -93,10 +93,9 @@ def DepMissing():
             time.sleep(15)
 
 
-def DepMinVersion():
+def dep_min_version():
+    # For classic: Checks for Maintainer specified to packages.
     # Dependencies needs to be manually resolved if Caster requires a certain version of dependency
-    # Restart Dragon between tests so pkg_resources.require can find packages
-    # DepMinVersion Assumes only one package will have "=="
     upgradelist = []
     listdependency = ([
         ["dragonfly2", ">=", "0.13.0", None],
@@ -124,17 +123,18 @@ def DepMinVersion():
 
 
 class DependencyMan:
+    # Initializes functions
     def __init__(self):
-        install = installtype()
-        findpip()
+        install = install_type()
+        find_pip()
         if install is "classic":
-            DepMinVersion()
-            DepMissing()
+            dep_min_version()
+            dep_missing()
         if settings.SETTINGS["miscellaneous"]["online_mode"]:
-            if internetcheck():
+            if internet_check():
                 if install is "pip":
-                    DependencyCheck(command="castervoice")
-                DependencyCheck(command="dragonfly2")
+                    dependency_check(command="castervoice")
+                dependency_check(command="dragonfly2")
             else:
                 print("\nCaster: Network off-line check network connection\n")
         else:

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -69,11 +69,11 @@ def dependency_check(command=None):
         out = p.communicate('')
         for line in out:
             if "INSTALLED" and "latest" in line:
-                print("Caster: {0} is up-to-date".format(command))
+                print("Caster: {0} is up-to-date".format(command.strip('2')))
                 update = False
                 break
             else:
-                print("Caster: Say 'Update {0}' to update.".format(command))
+                print("Caster: Say 'Update {0}' to update.".format(command.strip('2')))
                 update = True
                 break
     except Exception as e:
@@ -81,8 +81,9 @@ def dependency_check(command=None):
 
 
 def dep_missing():
-    # For classic: Parsesrequirements.txt checking for missing pip packages
-    with open('D:\\Backup\\Library\\Documents\\Caster\\requirements.txt') as f:
+    base = os.path.normpath(settings.SETTINGS["paths"]["BASE_PATH"] + os.sep + os.pardir)
+    requirements = os.path.join(base, "requirements.txt")
+    with open(requirements) as f:
         requirements = f.read().splitlines()
     for dep in requirements:
         try:
@@ -95,11 +96,11 @@ def dep_missing():
 
 
 def dep_min_version():
-    # For classic: Checks for Maintainer specified to packages.
-    # Dependencies needs to be manually resolved if Caster requires a certain version of dependency
+    # For classic: Checks for Maintainer specified package requirements.
+    # Needs to be manually resolved if Caster requires a specific version of dependency
     upgradelist = []
     listdependency = ([
-        ["dragonfly2", ">=", "0.13.0", None],
+        ["dragonfly2", ">=", "0.14.1", None],
     ])
     for dep in listdependency:
         package = dep[0]

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -25,7 +25,7 @@ def find_pip():
 
 
 def install_type():
-    # Checks if install is Classic or PIP of caster
+    # Checks if Caster install is Classic or PIP.
     try:
         pkg_resources.require("castervoice")
     except VersionConflict:
@@ -53,7 +53,7 @@ def internet_check(host="1.1.1.1", port=53, timeout=3):
 
 
 def dependency_check(command=None):
-    # For classic/pip: Check for updates Caster and Dragonfly
+    # Check for updates pip packages castervoice/dragonfly2
     com = [pip_path, "search", command]
     startupinfo = None
     global update
@@ -81,6 +81,7 @@ def dependency_check(command=None):
 
 
 def dep_missing():
+    # For classic: Checks for missing dependencies parsing requirements.txt
     base = os.path.normpath(settings.SETTINGS["paths"]["BASE_PATH"] + os.sep + os.pardir)
     requirements = os.path.join(base, "requirements.txt")
     with open(requirements) as f:
@@ -98,6 +99,7 @@ def dep_missing():
 def dep_min_version():
     # For classic: Checks for Maintainer specified package requirements.
     # Needs to be manually resolved if Caster requires a specific version of dependency
+    # A GitHub Issue URL needed to explain the change to version specific '==' dependency.
     upgradelist = []
     listdependency = ([
         ["dragonfly2", ">=", "0.14.1", None],
@@ -106,14 +108,16 @@ def dep_min_version():
         package = dep[0]
         operator = dep[1]
         version = dep[2]
-        url = dep[3]
+        issueurl = dep[3]
         try:
             pkg_resources.require('{0} {1} {2}'.format(package, operator, version))
         except VersionConflict as e:
             if operator is ">=":
                 upgradelist.append('{0}'.format(package))
             if operator is "==":
-                print("\nCaster: Requires an exact version of dependencies")
+                print(
+                    "\nCaster: Requires an exact version of dependencies. Issue reference: {0} \n"
+                    .format(issueurl))
                 print("Install the exact version: 'pip install {0}'".format(e.req))
     if not upgradelist:
         pass


### PR DESCRIPTION
When developing Caster sometimes dependencies change between releases or require a locked version. This whole request implements a method of informing users of the change in dependencies.

- Allows maintainers to define minimum and specific version of dependencies. To be used between releases as a method of informing contributors of changes with dependency.
- Checks for missing dependency reading `requirements.txt`
- Enhanced message that guides the user to install dependencies.
- Suppresses traceback
- If a dependency is missing the main thread sleeps for 15 seconds with both WRS and Natlink
- Moves all dependency related functions out of `_caster.py` to `dependencies.py` except for the grammar.




