### PR TITLE
Removed the shadowed dragon format command and added updated dra…

### DIFF
--- a/castervoice/apps/dragon.py
+++ b/castervoice/apps/dragon.py
@@ -2,6 +2,7 @@ from castervoice.lib.imports import *
 
 _NEXUS = control.nexus()
 
+
 def fix_dragon_double(nexus):
     try:
         lr = nexus.history[len(nexus.history) - 1]
@@ -10,39 +11,42 @@ def fix_dragon_double(nexus):
     except Exception:
         utilities.simple_log(False)
 
+
 def cap_dictation(dictation):
     input_list = str(dictation).split(" ")
     output_list = []
     for i in range(len(input_list)):
         if input_list[i] == "cap":
-            input_list[i+1] = input_list[i+1].title()
+            input_list[i + 1] = input_list[i + 1].title()
         else:
             output_list.append(input_list[i])
     Text(" ".join(output_list)).execute()
 
+
 # extras are common to both classes in this file
 extras_for_whole_file = [
-        Dictation("text"),
-        IntegerRefST("n10", 1, 10),
-        Choice("first_second_third", {
-            "first": 0,
-            "second": 1,
-            "third": 2,
-            "fourth": 3,
-            "fifth": 4,
-            "six": 5,
-            "seventh": 6
-        }),
+    Dictation("text"),
+    IntegerRefST("n10", 1, 10),
+    Choice("first_second_third", {
+        "first": 0,
+        "second": 1,
+        "third": 2,
+        "fourth": 3,
+        "fifth": 4,
+        "six": 5,
+        "seventh": 6
+    }),
+]
+defaults_for_whole_file = {
+    "n10": 1,
+    "text": "",
+}
 
-    ]
-defaults_for_whole_file = {"n10": 1, "text": "",}
 
 class DragonRule(MergeRule):
     pronunciation = "dragon"
 
     mapping = {
-        "format <text>":
-            Function(cap_dictation, extra={"text"}),
         '(lock Dragon | deactivate)':
             R(Playback([(["go", "to", "sleep"], 0.0)])),
         '(number|numbers) mode':
@@ -62,49 +66,53 @@ class DragonRule(MergeRule):
         "fix dragon double":
             R(Function(fix_dragon_double, nexus=_NEXUS)),
         "left point":
-            R(Playback([(["MouseGrid"], 0.1), (["four", "four"], 0.1), (["click"], 0.0)])),
+            R(Playback([(["MouseGrid"], 0.1), (["four", "four"], 0.1),
+                        (["click"], 0.0)])),
         "right point":
             R(Playback([(["MouseGrid"], 0.1), (["six", "six"], 0.1), (["click"], 0.0)])),
         "center point":
             R(Playback([(["MouseGrid"], 0.1), (["click"], 0.0)])),
-
-
         "show windows":
             R(Mimic("list", "all", "windows")),
         "cory <text>":
-            R(Mimic("correct", extra="text") + WaitWindow(title="spelling window") + Mimic("choose", "one")),
+            R(
+                Mimic("correct", extra="text") + WaitWindow(title="spelling window") +
+                Mimic("choose", "one")),
         "cory that":
-            R(Mimic("correct", "that") + WaitWindow(title="spelling window") + Mimic("choose", "one")),
-
+            R(
+                Mimic("correct", "that") + WaitWindow(title="spelling window") +
+                Mimic("choose", "one")),
         "make that <text>":
             R(Mimic("scratch", "that") + Mimic(extra="text")),
         "scratch [<n10>]":
             R(Playback([(["scratch", "that"], 0.03)])),
-
         "train word":
             R(Mimic("train", "that") + Key("a-r/200, s")),
         "word train":
-            R(Key("c-c/20") + Mimic("edit", "vocabulary") + Pause("100") +
-            Key("c-v/5, tab, down, up, a-t/50, enter/50, a-r/250, s/50, escape")),
+            R(
+                Key("c-c/20") + Mimic("edit", "vocabulary") + Pause("100") +
+                Key("c-v/5, tab, down, up, a-t/50, enter/50, a-r/250, s/50, escape")),
         "(add train | train from add word)":
             R(Key("a-a/2, enter/300, a-s")),
-    # Users may want to adjust the way time on the next four commands
+        # Users may want to adjust the way time on the next four commands
         "(train from vocab | cab train)":
             R(Key("a-t/50, enter/50, a-r/250, s")),
         "(train from vocab | cab train)":
             R(Key("a-t/50, enter/50, a-r/250, s")),
         "remove from vocab":
-            R(Key("c-c/5") + Mimic("edit", "vocabulary") + Pause("20") +
-            Key("c-v/10, tab, down, up/5, a-d, y, escape/30, right")),
+            R(
+                Key("c-c/5") + Mimic("edit", "vocabulary") + Pause("20") +
+                Key("c-v/10, tab, down, up/5, a-d, y, escape/30, right")),
         "(add to vocab | vocab that)":
-            R(Key("c-c/5") + Mimic("add", "word") + Pause("20") +
-            Key("c-v, a-a/2, enter/300, a-s/30, right")),
-
+            R(
+                Key("c-c/5") + Mimic("add", "word") + Pause("20") +
+                Key("c-v, a-a/2, enter/300, a-s/30, right")),
         "recognition history":
             R(Playback([(["view", "recognition", "history"], 0.03)])),
         "peak [recognition] history":
-            R(Playback([(["view", "recognition", "history"], 0.03)])
-                + Pause("300") + Key("escape")),
+            R(
+                Playback([(["view", "recognition", "history"], 0.03)]) + Pause("300") +
+                Key("escape")),
         "[dictation] sources":
             R(Mimic("manage", "dictation", "sources")),
 
@@ -119,18 +127,18 @@ class DragonRule(MergeRule):
 
 class SpellingWindowRule(MergeRule):
     mapping = {
-         # todo: make these CCR
-         "<first_second_third> word":
+        # todo: make these CCR
+        "<first_second_third> word":
             R(Key("home, c-right:%(first_second_third)d, cs-right")),
-         "last [word]":
+        "last [word]":
             R(Key("right, cs-left")),
-         "second [to] last word":
+        "second [to] last word":
             R(Key("right, c-left:1, cs-left")),
-         "<n10>":
+        "<n10>":
             R(Mimic("choose", extra="n10")),
-            # consider making the above command global so that it works when you say something like
-            # "insert before 'hello'" where there are multiple instances of 'hello'
-            # personally I think it's better just to have the setting where Dragon choose is the closest instance
+        # consider making the above command global so that it works when you say something like
+        # "insert before 'hello'" where there are multiple instances of 'hello'
+        # personally I think it's better just to have the setting where Dragon choose is the closest instance
     }
 
     # see above

--- a/castervoice/apps/dragon.py
+++ b/castervoice/apps/dragon.py
@@ -75,12 +75,10 @@ class DragonRule(MergeRule):
         "show windows":
             R(Mimic("list", "all", "windows")),
         "cory <text>":
-            R(
-                Mimic("correct", extra="text") + WaitWindow(title="spelling window") +
+            R(Mimic("correct", extra="text") + WaitWindow(title="spelling window") +
                 Mimic("choose", "one")),
         "cory that":
-            R(
-                Mimic("correct", "that") + WaitWindow(title="spelling window") +
+            R(Mimic("correct", "that") + WaitWindow(title="spelling window") +
                 Mimic("choose", "one")),
         "make that <text>":
             R(Mimic("scratch", "that") + Mimic(extra="text")),
@@ -89,8 +87,7 @@ class DragonRule(MergeRule):
         "train word":
             R(Mimic("train", "that") + Key("a-r/200, s")),
         "word train":
-            R(
-                Key("c-c/20") + Mimic("edit", "vocabulary") + Pause("100") +
+            R(Key("c-c/20") + Mimic("edit", "vocabulary") + Pause("100") +
                 Key("c-v/5, tab, down, up, a-t/50, enter/50, a-r/250, s/50, escape")),
         "(add train | train from add word)":
             R(Key("a-a/2, enter/300, a-s")),
@@ -100,18 +97,15 @@ class DragonRule(MergeRule):
         "(train from vocab | cab train)":
             R(Key("a-t/50, enter/50, a-r/250, s")),
         "remove from vocab":
-            R(
-                Key("c-c/5") + Mimic("edit", "vocabulary") + Pause("20") +
+            R(Key("c-c/5") + Mimic("edit", "vocabulary") + Pause("20") +
                 Key("c-v/10, tab, down, up/5, a-d, y, escape/30, right")),
         "(add to vocab | vocab that)":
-            R(
-                Key("c-c/5") + Mimic("add", "word") + Pause("20") +
+            R(Key("c-c/5") + Mimic("add", "word") + Pause("20") +
                 Key("c-v, a-a/2, enter/300, a-s/30, right")),
         "recognition history":
             R(Playback([(["view", "recognition", "history"], 0.03)])),
         "peak [recognition] history":
-            R(
-                Playback([(["view", "recognition", "history"], 0.03)]) + Pause("300") +
+            R(Playback([(["view", "recognition", "history"], 0.03)]) + Pause("300") +
                 Key("escape")),
         "[dictation] sources":
             R(Mimic("manage", "dictation", "sources")),

--- a/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
+++ b/castervoice/doc/readthedocs/Application_Commands_Quick_Reference.md
@@ -166,13 +166,18 @@
 
 # Dragon
 
-| Command                      | Command             | Command       |
-|:-----------------------------|:--------------------|:--------------|
-| `(lock Dragon / deactivate)` | `dictation mode`    | `right point` |
-| `(number/numbers) mode`      | `fix dragon double` | `scratch`     |
-| `center point`               | `left point`        | `spell mode`  |
-| `com off`                    | `normal mode`       |               |
-| `com on`                     | `reboot dragon`     |               |
+| Command                      | Command              | Command                          |
+|:-----------------------------|:---------------------|:---------------------------------|
+| `(lock Dragon / deactivate)` | `dictation mode`     | `right point`                    |
+| `(number/numbers) mode`      | `fix dragon double`  | `scratch`                        |
+| `center point`               | `left point`         | `spell mode`                     |
+| `com off`                    | `normal mode`        | `make that`                      |
+| `com on`                     | `reboot dragon`      | `train word`                     |
+| `left point`                 | `show windows`       | `word train`                     |
+| `right point`                | `cory <text>"`       | `add train / train from add word`|
+| `center point`               | `cory that`          | `dictation sources`              |
+| `add to vocab`               | `train from vocab`   | `recognition history`            |
+| `peak recognition history`   | `remove from vocab`  |                                  |
 
 # Eclipse
 


### PR DESCRIPTION
As per reported in Gitter
- `"format <text>"` was shadowed in dragon.py.
- The Function action isn't passing text properly

The removed command
`"format <text>": Function(cap_dictation, extra={"text"}),`

- Added missing documentation dragon.py commands.