### PR TITLE
Load word.txt from .caster\filters and documentation update

### DIFF
--- a/Index.md
+++ b/Index.md
@@ -30,7 +30,7 @@
 
 * [Easy Setup](caster/doc/Installation.md) and Configurable Settings
 
-* Customize commands(Specs) and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/CCR/#simplified-rule-filters) and [filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/examples/rules/Caster%20Rules/#rule-filters)([code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples)).
+* Customize commands(Specs) and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/CCR/#simplified-filter-rules) and [filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/examples/rules/Caster%20Rules/#rule-filters)([code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples)).
 
 * Compatible Speech Recognition Engines
 

--- a/Index.md
+++ b/Index.md
@@ -30,7 +30,7 @@
 
 * [Easy Setup](caster/doc/Installation.md) and Configurable Settings
 
-* Customize commands(Specs) and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/CCR/#rule-filters-simplified) and [filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/examples/rules/Caster%20Rules/#rule-filters)([code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples)).
+* Customize commands(Specs) and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/CCR/#simplified-rule-filters) and [filter rules](https://caster.readthedocs.io/en/latest/caster/doc/readthedocs/examples/rules/Caster%20Rules/#rule-filters)([code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples)).
 
 * Compatible Speech Recognition Engines
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include _caster.py
 include post_setup.py
 include ReadMe.md
 include castervoice/bin/data/configdebug.txt
-include castervoice/bin/share/bringme.toml.defaults
+include castervoice/bin/share/FilterRules/words.txt
 include castervoice/bin/share/git_repo_local_to_remote_match.toml.defaults
 include castervoice/bin/VirtualDesktopAccessor.dll
 include castervoice/bin/reboot.bat

--- a/castervoice/bin/share/FilterRules/words.txt
+++ b/castervoice/bin/share/FilterRules/words.txt
@@ -1,0 +1,6 @@
+<<<SPEC>>>
+shock -> earthquake
+<<<NOT_SPECS>>>
+sauce -> up
+dunce -> down
+lease -> left

--- a/castervoice/doc/index.md
+++ b/castervoice/doc/index.md
@@ -35,7 +35,7 @@ Donate at [![Bountysource](https://www.bountysource.com/badge/team?team_id=40790
 
 - Configurable Settings in `C:\Users\%USERNAME%\.caster`
 
-- Customize Commands aka `Specs` and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#rule-filters-simplified) and [filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#Rule-Filters)[code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples) (WIP).
+- Customize Commands aka `Specs` and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#simplified-rule-filters) and [filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#Rule-Filters)[code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples) (WIP).
 
 - Compatible Speech Recognition Engines
 

--- a/castervoice/doc/index.md
+++ b/castervoice/doc/index.md
@@ -35,7 +35,7 @@ Donate at [![Bountysource](https://www.bountysource.com/badge/team?team_id=40790
 
 - Configurable Settings in `C:\Users\%USERNAME%\.caster`
 
-- Customize Commands aka `Specs` and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#simplified-rule-filters) and [filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#Rule-Filters)[code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples) (WIP).
+- Customize Commands aka `Specs` and their actions via [simplified filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#simplified-filter-rules) and [filter rules](https://caster.readthedocs.io/en/latest/readthedocs/CCR/#Rule-Filters)[code](https://github.com/dictation-toolbox/caster/tree/master/caster/user/filters/examples) (WIP).
 
 - Compatible Speech Recognition Engines
 

--- a/castervoice/doc/readthedocs/CCR.md
+++ b/castervoice/doc/readthedocs/CCR.md
@@ -9,7 +9,7 @@
   - [Types of Rules](#types-of-rules)
   - [How to Add and Modify Rules](#how-to-add-and-modify-rules)
   - [Rule Filters](#rule-filters)
-    - [Rule Filters Simplified ](#rule-filters-simplified)
+    - [Simplified Rule Filters](#simplified-rule-filters)
   - [Other Features of MergeRule](#other-features-of-mergerule)
   - [How to Register Caster CCR Rules](#how-to-register-caster-ccr-rules)
 
@@ -65,9 +65,9 @@ Let's go through these.
 
 What rule filters do is expose pairs of rules to the user, allowing the user to change the rules' mapping as they see fit, and/or enable/disable compatibility checking which follows the rule filters. 
 
-#### Rule Filters Simplified
+#### Simplified Rule Filters
 
-Though rule filters are very powerful, setting one up for the first time is not trivial. Therefore, a simplified method for common use cases has been created. Create the file `.caster\data\words.txt` and it will be read at boot time, and a rule filter created from it and added to Caster's list of rule filters. The following is an example `words.txt`:
+Though rule filters are very powerful, setting one up for the first time is not trivial. Therefore, a simplified method for common use cases has been created. Create the file `.caster\filters\words.txt` and it will be read at boot time, and a rule filter created from it and added to Caster's list of rule filters. The following is an example `words.txt`:
 
 ```
 <<<SPEC>>>

--- a/castervoice/doc/readthedocs/CCR.md
+++ b/castervoice/doc/readthedocs/CCR.md
@@ -9,7 +9,7 @@
   - [Types of Rules](#types-of-rules)
   - [How to Add and Modify Rules](#how-to-add-and-modify-rules)
   - [Rule Filters](#rule-filters)
-    - [Simplified Rule Filters](#simplified-rule-filters)
+    - [Simplified Filter Rules](#simplified-filter-rules)
   - [Other Features of MergeRule](#other-features-of-mergerule)
   - [How to Register Caster CCR Rules](#how-to-register-caster-ccr-rules)
 
@@ -65,7 +65,7 @@ Let's go through these.
 
 What rule filters do is expose pairs of rules to the user, allowing the user to change the rules' mapping as they see fit, and/or enable/disable compatibility checking which follows the rule filters. 
 
-#### Simplified Rule Filters
+#### Simplified Filter Rules
 
 Though rule filters are very powerful, setting one up for the first time is not trivial. Therefore, a simplified method for common use cases has been created. Create the file `.caster\filters\words.txt` and it will be read at boot time, and a rule filter created from it and added to Caster's list of rule filters. The following is an example `words.txt`:
 

--- a/castervoice/lib/dfplus/merge/gfilter.py
+++ b/castervoice/lib/dfplus/merge/gfilter.py
@@ -122,9 +122,9 @@ class GlobalFilterDefs(object):
 
 DEFS = None
 
-if os.path.isfile(settings.SETTINGS["paths"]["FILTER_WORDS_DEFS_PATH"]):
-    '''user must create castervoice/user/fdefs.txt for it to get picked up here'''
-    with io.open(settings.SETTINGS["paths"]["FILTER_WORDS_DEFS_PATH"],
+if os.path.isfile(settings.SETTINGS["paths"]["SIMPLIFIED_FILTER_RULES_PATH"]):
+    '''User must create or place words.txt in '.caster\filters' folder for it to get picked up here'''
+    with io.open(settings.SETTINGS["paths"]["SIMPLIFIED_FILTER_RULES_PATH"],
                  "rt",
                  encoding="utf-8") as f:
         lines = f.readlines()
@@ -223,7 +223,7 @@ def spec_override_from_config(mp):
 
 
 if DEFS is not None:
-    print("Global rule filter from file 'words.txt' activated ...")
+    print("Global simplified rule filter 'words.txt' activated...")
 
 
 def run_on(rule):

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -201,8 +201,8 @@ _DEFAULT_SETTINGS = {
             _USER_DIR + "/data/ccr.toml",
         "DLL_PATH":
             BASE_PATH + "/lib/dll/",
-        "FILTER_WORDS_DEFS_PATH":
-            _USER_DIR + "/data/words.txt",
+        "SIMPLIFIED_FILTER_RULES_PATH":
+            _USER_DIR + "/filters/words.txt",
         "LOG_PATH":
             _USER_DIR + "/log.txt",
         "RECORDED_MACROS_PATH":


### PR DESCRIPTION
Since `word.txt` represents type of Rule Filter in the documentation it should be loaded from `.caster\filters`.

**Changes and Additions**
- Loads`word.txt` in `.caster\filters` instead of `.caster\data`
- Renamed `FILTER_WORDS_DEFS_PATH` to `SIMPLIFIED_FILTER_RULES_PATH` to reflect documentation.
- Renames documentation `Rule Filters Simplified` to `Simplified Filter Rules`.
- Added words.txt to `filters/examples`
- Added `words.txt `to `MANIFEST.in` include in the PIP package