### PR TITLE
add pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -49,12 +49,12 @@
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+- [ ] All new and existing tests pass.
 
 ## Maintainer/Reviewer Checklist
 
 !--- Please leave these unchecked and add any other specific tasks you would like a --
-!--- reviewer or maintainer to do. --
+!--- reviewer or maintainer to complete. --
 
 - [ ] Basic functionality has been tested and works as claimed.
 - [ ] New documentation is clear and complete.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,43 @@
+# Title
+
+!--- Provide a title for this pull request above --
+
+## Description
+
+!--- Describe your changes in detail --
+
+## Related Issue
+
+!--- Please reference any related issues here --
+
+## Motivation and Context
+
+!--- Why is this change required? What problem does it solve? --
+
+## How Has This Been Tested
+
+!--- Please describe in detail how you tested your changes. --
+!--- Include details of your testing environment, and the tests you ran to --
+!--- see how your change affects other areas of the code, etc. --
+
+## Types of changes
+
+!--- What types of changes does your code introduce Put an `x` in all the boxes that apply --
+
+- [ ] Docs change / refactoring / dependency upgrade
+- [ ] Bug fix (non-breaking change which fixes an issue or bug)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+!--- Go over all the following points, and put an `x` in all the boxes that apply. --
+!--- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. --
+!--- You may submit a pull request at any stage of completion to get feedback. --
+
+- [ ] I have read the CONTRIBUTING document.
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,6 @@
 # Title
 
-!--- Provide a title for this pull request above --
+!--- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.--
 
 ## Description
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -23,6 +23,7 @@
 ## Types of changes
 
 !--- What types of changes does your code introduce Put an `x` in all the boxes that apply --
+!--- and delete the options that do not apply. --
 
 - [ ] Docs change / refactoring / dependency upgrade
 - [ ] Bug fix (non-breaking change which fixes an issue or bug)
@@ -34,6 +35,8 @@
 !--- Go over all the following points, and put an `x` in all the boxes that apply. --
 !--- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. --
 !--- You may submit a pull request at any stage of completion to get feedback. --
+!--- Please add further items to this checklist as appropriate and delete any items --
+!--- that do not apply. --
 
 - [ ] I have read the CONTRIBUTING document.
 - [ ] My code follows the code style of this project.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -29,6 +29,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue or bug)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Renamed existing command phrases (we discourage this without a strong rationale).
 
 ## Checklist
 
@@ -42,6 +43,8 @@
 
 - [ ] I have read the CONTRIBUTING document.
 - [ ] My code follows the code style of this project.
+- [ ] I have checked that my code does not duplicate functionality elsewhere in Caster.
+- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
 - [ ] My code implements all the features I wish to merge in this pull request.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -36,24 +36,17 @@
 !--- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. --
 !--- You may submit a pull request at any stage of completion to get feedback. --
 !--- Please add further items to this checklist as appropriate and delete any items --
-!--- that do not apply. --
+!--- that do not apply. If you leave the "My code implements all the features -- 
+!--- I wish to merge in this pull request." box unchecked we will not review the code --
+!--- unless requested. --
 
 - [ ] I have read the CONTRIBUTING document.
 - [ ] My code follows the code style of this project.
+- [ ] My code implements all the features I wish to merge in this pull request.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
-
-
-## Pull Request Status as defined by Contributor.
-!--- Please check one of the following boxes to indicate the status of the pull request --
-!--- Marking 'Complete' states that you believe the pull request is ready to be merged and feature complete --
-!--- Marking 'Work in progress (WIP)' means you are still developing features. Code Review upon request only. --
-!--- Once the status is is checked as complete the pull request is ready review by a Maintainer--
-
-- [ ] Work in progress (WIP)
-- [ ] Complete
 
 ## Maintainer/Reviewer Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -45,6 +45,16 @@
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 
+
+## Pull Request Status as defined by Contributor.
+!--- Please check one of the following boxes to indicate the status of the pull request --
+!--- Marking 'Complete' states that you believe the pull request is ready to be merged and feature complete --
+!--- Marking 'Work in progress (WIP)' means you are still developing features. Code Review upon request only. --
+!--- Once the status is is checked as complete the pull request is ready review by a Maintainer--
+
+- [ ] Work in progress (WIP)
+- [ ] Complete
+
 ## Maintainer/Reviewer Checklist
 
 !--- Please leave these unchecked and add any other specific tasks you would like a --

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -44,3 +44,12 @@
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
+
+## Maintainer/Reviewer Checklist
+
+!--- Please leave these unchecked and add any other specific tasks you would like a --
+!--- reviewer or maintainer to do. --
+
+- [ ] Basic functionality has been tested and works as claimed.
+- [ ] New documentation is clear and complete.
+- [ ] Code is clear and readable.


### PR DESCRIPTION
# This PR uses the proposed template

## Description

This pull request adds a template for adding pull requests.

## Related Issue

None.

## Motivation and Context

Having a template for pull requests helps to add a little discipline to the process and helps to remind contributors what needs to be done before something gets merged.

## How Has This Been Tested

I have done no testing as it needs to be merged in order to test with GitHub.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
