### PR TITLE
Bring me for files and folders

### DIFF
--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -13,7 +13,7 @@ class BringRule(SelfModifyingRule):
             "bring me <folder> [in <app>]": R(Function(self.bring_folder)),
             "bring me <file>": R(Function(self.bring_file)),
             "refresh bring me": R(Function(self.load_and_refresh)),
-            "<program> to bring me as <key>": R(Function(self.bring_add)),
+            "<launch> to bring me as <key>": R(Function(self.bring_add)),
             "to bring me as <key>": R(Function(self.bring_add_auto)),
             "remove <key> from bring me": R(Function(self.bring_remove)),
             "restore bring me defaults": R(Function(self.bring_restore)),
@@ -80,8 +80,12 @@ class BringRule(SelfModifyingRule):
             if not path:
                 # dragonfly.get_engine().speak("program not detected")
                 print("Program path for bring me not found ")
-        # elif launch == 'file':
-        # no way to add file via pyperclip
+        elif launch == 'file':
+            files = utilities.get_selected_files(folders=False)
+            path = files[0] if files else None # or allow adding multiple files
+        elif launch == 'folder':
+            files = utilities.get_selected_files(folders=True)
+            path = files[0] if files else None # or allow adding multiple folders
         else:
             Key("a-d/5").execute()
             fail, path = context.read_selected_without_altering_clipboard()

--- a/docs/readthedocs/Bringme.md
+++ b/docs/readthedocs/Bringme.md
@@ -1,0 +1,27 @@
+# Bring me
+
+_Bring me_ is a function that allows the user to quickly invoke an item from a list of previously saved items. Currently these items are: programs, websites, folders, and files. The list of items is saved to the Caster user directory to the file bringme.toml. On first installation, if no list of items exists yet, default list is created with some documentation websites, common computer folders and some Caster settings files.
+
+`<launch> to bring me as <key>`: adds current element, which may be a website, program, folder, or file, to the list of items to be able to invoke it later by uttering `key`
+
+`to bring me as <key>`: same as above, but the "launch" is detected automatically, based on if you are in a web browser, Windows Explorer, or the terminal
+
+`bring me <item>` : brings up the `item` in a way dependent on the type of the item. It can be:
+
+- a website: launches the default system browser opening the desired site
+- a program: launches the program
+- a folder: opens the desired folder; if `in terminal` or `in explorer` is appended, opens the folder explicitly in this. Default is opening in the Windows Explorer.
+- a file: opens the file with its default associated program
+
+`refresh bring me`: refreshes the bring me grammar and synchronizes it with its settings. This is useful if you edit the bringme.toml file directly.
+
+`remove <key> from bring me`: removes the utterance `key` from the list of items to launch
+            "restore bring me defaults": R(Function(self.bring_restore)),
+
+`restore bring me defaults`: clears the list of items and restores its default values
+
+## Example
+
+When in Google Chrome, saying "program to bring me as my favorite browser" saves Google Chrome as a program, which can be launched by saying "bring me my favorite browser".
+
+When in a browser (currently Google Chrome and Firefox are supported), saying "Website to bring me as my little pony" will save the current website so that it can be brought up later by saying "my little pony" in a new tab, if the default system browser is already running, or in a new browser window.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
     - Documentation:
         - Aenea: readthedocs/Aenea.md
         - Alias: readthedocs/Alias.md
+        - Bring me: readthedocs/Bringme.md
         - Application Commands Quick Reference: readthedocs/Application_Commands_Quick_Reference.md
         - Auto CCR and Cmd Mode: readthedocs/Auto_CCR_and_Cmd-Mode.md
         - CCR: readthedocs/CCR.md


### PR DESCRIPTION
Adding files and folders should work from Windows Explorer (and everywhere files can be copied). Closes #575. Path detection in the end with copying and `win32clipboard` Remarks:

- There was a bug, adding anything did not work?
- Uses Dragonfly's clipboard as well as pywin32's win32clipboard
- The link "caster discord" displays an expired Discord invitation - is there a Discord channel?
