### PR TITLE
add grammar documentation template

### DIFF
--- a/docs/readthedocs/GRAMMAR_DOCUMENTATION_TEMPLATE.md
+++ b/docs/readthedocs/GRAMMAR_DOCUMENTATION_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Title
+
+<!-- Insert a short description here. -->
+
+## Commands
+
+- Very short command description: `<target> in code [<form>]`
+    - Describe the variables here and add further explanation for this command. `<target>` is a variable that needs an explanation, for example. `<target>` might be _sauce_ or _dunce_. Refer to variables, e.g. `<form>`, using `backticks` and refer to spoken phrases using _italics_.
+
+## Examples
+
+- _sauce in code_
+    - If not obvious what the example does, add a description here.
+- _sauce in code form_
+    - Try to cover a lot of different possible examples as lots of people learn this way before reading the proper documentation.


### PR DESCRIPTION
# Add Grammar Documentation Template

## Description

This pull request adds a template for grammar documentation (e.g. `Mouse.md`, `Text_Manipulation.md`, and `Bringme.md`).

## Related Issue

None.

## Motivation and Context

There was a lot of style inconsistency in the documentation and this pull request aims to prevent that. It provides a template for adding new documentation, as well as defining some style conventions (subject to change upon discussion). In particular, it asks that can phrases be referred to using _italics_ and variables in the command phrase spec be referred to using `backticks`.

## How Has This Been Tested

No testing yet.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [x] New documentation is clear and complete.
- [ ] Code is clear and readable.
