### PR TITLE
Changed output of Retrieve() from Text to dragonfly Paste action

### DIFF
--- a/castervoice/lib/temporary.py
+++ b/castervoice/lib/temporary.py
@@ -1,7 +1,6 @@
-from dragonfly import ActionBase
+from dragonfly import ActionBase, Paste
 from castervoice.lib import context, control
 from castervoice.lib.actions import Text, Key
-
 '''
 Stores the currently highlighted text in a temporary variable,
 to be Retrieved after some other action. If no text was
@@ -36,6 +35,7 @@ clipboard, an empty string will be stored. This is a necessary
 side-effect of being able to detect when no text is highlighted.
 '''
 
+
 class Store(ActionBase):
     def __init__(self, space=" ", remove_cr=False):
         ActionBase.__init__(self)
@@ -61,7 +61,7 @@ class Retrieve(ActionBase):
 
     def _execute(self, data=None):
         output = control.nexus().temp
-        Text(output).execute()
+        Paste(output).execute()
         if output:
             Key(self.action_if_text).execute()
         else:


### PR DESCRIPTION
## Description

Changed output of Retrieve() from text to dragonfly paste action

## Motivation and Context

`Text(output).execute()` vs `Paste(output).execute()`

Current implementation `Text(output).execute()` for `Retrieve()` does not handle multiline text. This is not noticeable except for applications where pressing `enter` sends text. E.G chat application like Gitter. `Text` seems to use enter key between each line. This means if you Retrieve() a multiline text it sends each line as its own message.

To work around this dragonfly `Paste` achieves the same functional purpose of `text` without the drawbacks mentioned.

## How Has This Been Tested

I've tested this with multiline and single-line text fields with varying implementations of `Store() Retrieve()` and in gitter/sublime.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue or bug)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
