### PR TITLE
MarkDown CCR: Added store and retrieve

### DIFF
--- a/castervoice/lib/ccr/markdown/markdown.py
+++ b/castervoice/lib/ccr/markdown/markdown.py
@@ -1,21 +1,20 @@
 from castervoice.lib.imports import *
 
+
 class Markdown(MergeRule):
     pronunciation = "mark down"
 
     mapping = {
         "heading [<num>] [<dict>]":
-            R(Function(lambda num, dict:
-                Text(("#" * num) + " " + str(dict).capitalize() + "\n").execute())),
-
+            R(Store() + Function(lambda num, dict: Text(
+                ("#"*num) + " " + str(dict).capitalize()).execute()) + Retrieve() +
+              Key("enter")),
         "table row <n>":
-            R(Function(lambda n: Text("|"*(n-1)).execute()) + Key("home")),
+            R(Function(lambda n: Text("|"*(n - 1)).execute()) + Key("home")),
         "table (break | split) <n>":
-            R(Function(lambda n: Text("---|"*(n-1) + "---").execute()) + Key("enter")),
-
+            R(Function(lambda n: Text("---|"*(n - 1) + "---").execute()) + Key("enter")),
         "insert <element>":
-            R(Key("%(element)s")),
-
+            R(Store() + Key("%(element)s") + Retrieve(action_if_text="c-right")),
         "insert header":
             R(Text("---\nauthor: \ntitle: \n---\n")),
     }


### PR DESCRIPTION
## Description

Added `store and retrieve` to enhance MarkdownCCR. The default behavior is the same as the original and enhancements only activate with text is selected.

**Example:**
The command `insert <image>`   would print out `![]():` then the cursor would move left 3 times. Next with the word `MyPicture`  highlighted dictate  `insert <image>`. The final result being `![MyPicture]()`.  with the cursor at the end.

With the new commands highlighting any text will place the text in the appropriate context of the command.

## Related Issue!

https://github.com/dictation-toolbox/Caster/issues/650

## Motivation and Context

Leverages store and retrieve to highlight text. Current features it only leverages the keyboard this allows greater mixed input from selecting text Mouse or MouseGrids.

## How Has This Been Tested

It's been tested within the Gitter (Has trouble with the enter key instead of s-enter for a new line). Works in any other program that does not use enter key to send messages. 



## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
  not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.