### PR TITLE
fird -> firch

### DIFF
--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -266,7 +266,7 @@ class Navigation(MergeRule):
         "(lease wally | latch) [<nnavi10>]": R(Key("home:%(nnavi10)s")),
         "(ross wally | ratch) [<nnavi10>]": R(Key("end:%(nnavi10)s")),
         "bird [<nnavi500>]": R(Key("c-left:%(nnavi500)s")),
-        "fird [<nnavi500>]": R(Key("c-right:%(nnavi500)s")),
+        "firch [<nnavi500>]": R(Key("c-right:%(nnavi500)s")),
         "brick [<nnavi500>]": R(Key("s-left:%(nnavi500)s")),
         "frick [<nnavi500>]": R(Key("s-right:%(nnavi500)s")),
         "blitch [<nnavi500>]": R(Key("cs-left:%(nnavi500)s")),


### PR DESCRIPTION
I previously added a few one syllable commands for control/shift arrow keys. These are experimental, I have found that fird is commonly misrecognized for bird which is another command I added. so I'm replacing it with firch which after using for a week is working much better. similar changes may be required for other commands. Alexander's [Rosetta sheet](https://docs.google.com/spreadsheets/d/1pk2gwTFbMebgYSsrxIFsZ-QvpEPWCybF8ypdeBvfBsg/pubhtml) is a decent resource for this sort of thing. for example, it contains a one syllable alphabet apparently from voice code.IO.