### PR TITLE
Add refresh method to mock ChainAlias and use test discovery on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - pip install -U -r requirements-dev.txt
         - pip install -vvv --user -e .
       script:
-        - python castervoice/lib/tests/testrunner.py
+        - python -m unittest discover
         - pylint -E _caster.py        
         - pylint -E castervoice
 deploy:

--- a/castervoice/lib/tests/mocks.py
+++ b/castervoice/lib/tests/mocks.py
@@ -64,12 +64,14 @@ class Alias(AliasRule):
 
 class ChainAlias(AliasRule):
     pronunciation = "chain alias"
-    mapping = {
-        "alias":
-            Function(lambda: None),
-        "delete aliases":
-            Function(lambda: None),
-    }
+
+    def refresh(self, *args):
+        mapping = {
+            "alias":
+                Function(lambda: None),
+            "delete aliases":
+                Function(lambda: None),
+        }
 
 class EclipseRule(MergeRule):
     pronunciation = "eclipse"


### PR DESCRIPTION
Fixes tests. You can see now that mock alias classes are duplicate, but that is also, Apart from configuration, true about their original counterparts.