### PR TITLE
Use testrunner for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ matrix:
         - pip install -U -r requirements-dev.txt
         - pip install -vvv --user -e .
       script:
-        - python -m unittest discover
-        - pylint -E _caster.py        
-        - pylint -E castervoice
+        - python castervoice/lib/tests/testrunner.py && pylint -E _caster.py && pylint -E castervoice
 deploy:
   provider: pypi
   user: CasterVoice@protonmail.com

--- a/castervoice/lib/tests/testrunner.py
+++ b/castervoice/lib/tests/testrunner.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 from dragonfly.engines import _engines_by_name, get_engine
@@ -11,7 +12,8 @@ def get_master_suite():
     return unittest.defaultTestLoader.discover(os.path.dirname(__file__))
 
 def run_tests():
-    unittest.TextTestRunner(verbosity=2).run(get_master_suite())
+    return unittest.TextTestRunner(verbosity=2).run(get_master_suite())
 
 if __name__ == '__main__':
-    run_tests()
+    result = run_tests()
+    sys.exit(len(result.failures) + len(result.errors) + len(result.unexpectedSuccesses))


### PR DESCRIPTION
Playing with Travis, I think a better way is to 1.use testrunner, since it initializes the text engine, which I do not know how to do via commandline with test discovery, and 2. fail the script commands early