### PR TITLE
Longhand punctuation names

### DIFF
--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -265,6 +265,8 @@ class Navigation(MergeRule):
             rdescript="arrow keys"),
         "(lease wally | latch) [<nnavi10>]": R(Key("home:%(nnavi10)s")),
         "(ross wally | ratch) [<nnavi10>]": R(Key("end:%(nnavi10)s")),
+        "sauce wally [<nnavi10>]": R(Key("c-home:%(nnavi10)s")),
+        "dunce wally [<nnavi10>]": R(Key("c-end:%(nnavi10)s")),
         "bird [<nnavi500>]": R(Key("c-left:%(nnavi500)s")),
         "firch [<nnavi500>]": R(Key("c-right:%(nnavi500)s")),
         "brick [<nnavi500>]": R(Key("s-left:%(nnavi500)s")),

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -298,14 +298,10 @@ class Navigation(MergeRule):
     "(left | lease)": "left", "(right | ross)": "right", "(up | sauce)": "up",
     "(down | dunce)": "down", "page (down | dunce)": "pgdown", "page (up | sauce)": "pgup", "space": "space"}
     button_dictionary_10 = {"function {}".format(i):"f{}".format(i) for i in range(1, 10)}
-    # symbols = {"ampersand": "ampersand", "apostrophe": "apostrophe", "asterisk": "astersk", "(at | atty): at",
-        # "backslash": "backslash", "(backtick | ticky)": "backtick", "bar": "bar", "caret":"caret", ""}
-    
-    # button_dictionary_10.update(symbols)
     button_dictionary_10.update(caster_alphabet)
     button_dictionary_10.update(text_punc_dict)
     longhand_punctuation_names = {"minus": "hyphen", "hyphen":"hyphen", "comma": "comma",
-        "deckle": "colon", "colon": "colon", "slash": "slash"}
+        "deckle": "colon", "colon": "colon", "slash": "slash", "backslash": "backslash"}
     button_dictionary_10.update(longhand_punctuation_names)
     button_dictionary_1 = {"(home | lease wally | latch)": "home", "(end | ross wally | ratch)": "end", "insert": "insert", "zero": "0",
     "one": "1", "two": "2", "three": "3", "four": "4", "five": "5", "six":"6", "seven": "7", "eight": "8", "nine": "9"}

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -284,6 +284,7 @@ class Navigation(MergeRule):
               R(Key("%(modifier)s%(button_dictionary_1)s"),
               rdescript="press modifiers plus buttons from button_dictionary_1, non-repeatable"),
         
+        
         # "key stroke [<modifier>] <combined_button_dictionary>": 
         #     R(Text('Key("%(modifier)s%(combined_button_dictionary)s")')),
 
@@ -297,8 +298,15 @@ class Navigation(MergeRule):
     "(left | lease)": "left", "(right | ross)": "right", "(up | sauce)": "up",
     "(down | dunce)": "down", "page (down | dunce)": "pgdown", "page (up | sauce)": "pgup", "space": "space"}
     button_dictionary_10 = {"function {}".format(i):"f{}".format(i) for i in range(1, 10)}
+    # symbols = {"ampersand": "ampersand", "apostrophe": "apostrophe", "asterisk": "astersk", "(at | atty): at",
+        # "backslash": "backslash", "(backtick | ticky)": "backtick", "bar": "bar", "caret":"caret", ""}
+    
+    # button_dictionary_10.update(symbols)
     button_dictionary_10.update(caster_alphabet)
     button_dictionary_10.update(text_punc_dict)
+    longhand_punctuation_names = {"minus": "hyphen", "hyphen":"hyphen", "comma": "comma",
+        "deckle": "colon", "colon": "colon", "slash": "slash"}
+    button_dictionary_10.update(longhand_punctuation_names)
     button_dictionary_1 = {"(home | lease wally | latch)": "home", "(end | ross wally | ratch)": "end", "insert": "insert", "zero": "0",
     "one": "1", "two": "2", "three": "3", "four": "4", "five": "5", "six":"6", "seven": "7", "eight": "8", "nine": "9"}
     combined_button_dictionary = {}


### PR DESCRIPTION
In dragonfly2, Key("&") works but Key("/") does not; you need to use the longhand Key("slash") . Similarly with The hyphen, comma, and colon. This pull request changes the button dictionaries to use that longhand format in those cases. This applies to the commands for pressing buttons (e.g. modifier keys) and the voice dev commands.