### PR TITLE
add longhand punctuation names

### DIFF
--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -299,6 +299,9 @@ class Navigation(MergeRule):
     button_dictionary_10 = {"function {}".format(i):"f{}".format(i) for i in range(1, 10)}
     button_dictionary_10.update(caster_alphabet)
     button_dictionary_10.update(text_punc_dict)
+    longhand_punctuation_names = {"minus": "hyphen", "hyphen":"hyphen", "comma": "comma",
+        "deckle": "colon", "colon": "colon", "slash": "slash", "backslash": "backslash"}
+    button_dictionary_10.update(longhand_punctuation_names)
     button_dictionary_1 = {"(home | lease wally | latch)": "home", "(end | ross wally | ratch)": "end", "insert": "insert", "zero": "0",
     "one": "1", "two": "2", "three": "3", "four": "4", "five": "5", "six":"6", "seven": "7", "eight": "8", "nine": "9"}
     combined_button_dictionary = {}


### PR DESCRIPTION
In dragonfly2, Key("&") works but Key("/") does not; you need to use the longhand Key("slash") . Similarly with The hyphen, comma, and colon. This pull request changes the button dictionaries to use that longhand format in those cases. This applies to the commands for pressing buttons (e.g. modifier keys) and the voice dev commands.
When I originally made a pull request to this effect #666, I did so improperly and so I closed that and and replacing it with this one.