### PR TITLE
consolidate double punctuation, hug, and formatting e.g. snake

### DIFF
--- a/castervoice/apps/dragon.py
+++ b/castervoice/apps/dragon.py
@@ -12,16 +12,6 @@ def fix_dragon_double(nexus):
         utilities.simple_log(False)
 
 
-def cap_dictation(dictation):
-    input_list = str(dictation).split(" ")
-    output_list = []
-    for i in range(len(input_list)):
-        if input_list[i] == "cap":
-            input_list[i + 1] = input_list[i + 1].title()
-        else:
-            output_list.append(input_list[i])
-    Text(" ".join(output_list)).execute()
-
 
 # extras are common to both classes in this file
 extras_for_whole_file = [
@@ -47,7 +37,6 @@ class DragonRule(MergeRule):
     pronunciation = "dragon"
 
     mapping = {
-        "format <text>": Function(cap_dictation, extra={"text"}),
         '(lock Dragon | deactivate)':
             R(Playback([(["go", "to", "sleep"], 0.0)])),
         '(number|numbers) mode':

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -232,22 +232,24 @@ class Navigation(MergeRule):
         "peek [<big>] format":
             R(Function(textformat.peek_text_format)),
        
-        "[<big>] format <textnv>":
+  
+        # the next three commands put a space at the end
+        "([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
+            R(Function(enclose_format)), # combination enclosure, spacing, and capitalization command
+        "spay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
+            R(Text(" ") + Function(enclose_format)), # same as above, puts space at the beginning
+        "phrase <textnv> [(brunt | over)]": R(Function(enclose_format)), # mid utterance dictation command like "format"
+        # the next four commands do not put a space at the end
+        "nay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
+            R(Function(enclose_format) + Key("backspace")), # combination enclosure, spacing, and capitalization command  
+        "<enclosure>": R(Function(enclose_format)), # this is to e.g. type a pair of parentheses and put the cursor in between them
+        "[<big>] format <textnv> [(brunt | over)]":
             R(Function(textformat.prior_text_format)),
-        "<word_limit> [<big>] format <textnv>":
+        "<word_limit> [<big>] format <textnv> [(brunt | over)]":
             R(Function(textformat.partial_format_text)),
         "hug <enclosure> [<capitalization>] [<spacing>]":
             R(Function(enclose_format, hug=True)),
-        "([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
-            R(Function(enclose_format)),
-        "bound ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
-            R(Text(" ") + Function(enclose_format) + Text(" ")), 
-        "spay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
-            R(Text(" ") + Function(enclose_format)), 
-        "skay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
-            R(Function(enclose_format) + Text(" ")),    
-        "phrase <textnv> [brunt]": R(Function(enclose_format)),
-                   
+
 
         "dredge [<nnavi10>]":
             R(Key("alt:down, tab/20:%(nnavi10)d, alt:up"),

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -235,11 +235,18 @@ class Navigation(MergeRule):
             R(Function(textformat.prior_text_format)),
         "<word_limit> [<big>] format <textnv>":
             R(Function(textformat.partial_format_text)),
-        "(<enclosure> [<capitalization>] [<spacing>] | (<capitalization> | <spacing> | <capitalization> <spacing>)) [(bow|bowel)] [<textnv>] [(over | brunt)]":
+        "<enclosure> [<textnv>] [(over | brunt)]":
             R(Function(enclose_format)),
-        "long [<enclosure>] [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
-            R(Text(" ") + Function(enclose_format) + Text(" ")),    
-        "hug <enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
+        "((<enclosure> [<capitalization>] [<spacing>]) | (<capitalization> <spacing> | <capitalization> | <spacing>)) [(bow|bowel)] <textnv> [brunt]": 
+            R(Function(enclose_format)),
+        "bound [<enclosure>] [<capitalization>] [<spacing>] [<textnv>] [brunt]":
+            R(Text(" ") + Function(enclose_format) + Text(" ")), 
+        "spay [<enclosure>] [<capitalization>] [<spacing>] <textnv> [brunt]":
+            R(Text(" ") + Function(enclose_format)), 
+        "skay [<enclosure>] [<capitalization>] [<spacing>] <textnv> [brunt]":
+            R(Function(enclose_format) + Text(" ")),    
+        "phrase <textnv> [brunt]": R(Function(enclose_format)),
+        "hug <enclosure> [<capitalization>] [<spacing>]":
             R(Function(enclose_format, hug=True)),
             # R(Function(text_utils.enclose_selected)),
 
@@ -408,6 +415,7 @@ class Navigation(MergeRule):
         "splatdir": "backspace",
         "modifier": "",
         "enclosure": "",
+        
     }
 
 

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -1,3 +1,4 @@
+
 '''
 Created on Sep 1, 2015
 
@@ -237,25 +238,15 @@ class Navigation(MergeRule):
             R(Function(textformat.partial_format_text)),
         "hug <enclosure> [<capitalization>] [<spacing>]":
             R(Function(enclose_format, hug=True)),
-        "[<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) [(bow|bowel)] <textnv> [brunt]": 
+        "([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
             R(Function(enclose_format)),
-        "bound [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) [<textnv>] [brunt]":
+        "bound ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
             R(Text(" ") + Function(enclose_format) + Text(" ")), 
-        "spay [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) <textnv> [brunt]":
+        "spay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
             R(Text(" ") + Function(enclose_format)), 
-        "skay [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) <textnv> [brunt]":
+        "skay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
             R(Function(enclose_format) + Text(" ")),    
-        # when inner_formatting=False, we can say "cap" to capitalize words within dictation.
-        # that is the purpose of the repeated commands below
-        "<enclosure> [<textnv>] [(over | brunt)]":
-            R(Function(enclose_format, inner_formatting=False)),
-        "bound [<enclosure>] [<textnv>] [brunt]":
-            R(Text(" ") + Function(enclose_format, inner_formatting=False) + Text(" ")), 
-        "spay [<enclosure>] <textnv> [brunt]":
-            R(Text(" ") + Function(enclose_format, inner_formatting=False)), 
-        "skay [<enclosure>] <textnv> [brunt]":
-            R(Function(enclose_format, inner_formatting=False) + Text(" ")),    
-        "phrase <textnv> [brunt]": R(Function(enclose_format, inner_formatting=False)),
+        "phrase <textnv> [brunt]": R(Function(enclose_format)),
                    
 
         "dredge [<nnavi10>]":
@@ -363,6 +354,7 @@ class Navigation(MergeRule):
         Choice("combined_button_dictionary", combined_button_dictionary),
         
         Choice("capitalization", {
+            "rarb": -1,
             "yell": 1,
             "tie": 2,
             "Gerrish": 3,

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -6,19 +6,12 @@ Created on Sep 1, 2015
 from castervoice.lib.imports import *
 from dragonfly.actions.action_mimic import Mimic
 from castervoice.lib.ccr.standard import SymbolSpecs
-from castervoice.lib.ccr.core.punctuation import text_punc_dict, double_text_punc_dict
+from castervoice.lib.ccr.core.punctuation import text_punc_dict, enclosure
 from castervoice.lib.alphanumeric import caster_alphabet
+from castervoice.lib.textformat import master_format_text, enclose_format
 
 
 _NEXUS = control.nexus()
-
-for key, value in double_text_punc_dict.items():
-    if len(value) == 2:
-        double_text_punc_dict[key] = value[0] + "~" + value[1]
-    elif len(value) == 4:
-        double_text_punc_dict[key] = value[0:1] + "~" + value[2:3]
-    else:
-        raise Exception("Need to deal with nonstandard pair length in double_text_punc_dict.")
 
 class NavigationNon(MergeRule): 
     mapping = {
@@ -161,6 +154,8 @@ class NavigationNon(MergeRule):
     }
 
 
+
+
 class Navigation(MergeRule):
     non = NavigationNon
     pronunciation = CCRMerger.CORE[1]
@@ -235,15 +230,17 @@ class Navigation(MergeRule):
             R(Function(textformat.clear_text_format)),
         "peek [<big>] format":
             R(Function(textformat.peek_text_format)),
-        "(<capitalization> <spacing> | <capitalization> | <spacing>) [(bow|bowel)] <textnv> [brunt]":
-            R(Function(textformat.master_format_text)),
+       
         "[<big>] format <textnv>":
             R(Function(textformat.prior_text_format)),
         "<word_limit> [<big>] format <textnv>":
             R(Function(textformat.partial_format_text)),
+        "<enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
+            R(Function(enclose_format)),    
+        "hug <enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
+            R(Function(enclose_format, hug=True)),
+            # R(Function(text_utils.enclose_selected)),
 
-        "hug <enclosure>":
-            R(Function(text_utils.enclose_selected)),
         "dredge [<nnavi10>]":
             R(Key("alt:down, tab/20:%(nnavi10)d, alt:up"),
                rdescript="Core: switch to most recent Windows"),
@@ -287,7 +284,9 @@ class Navigation(MergeRule):
         # "key stroke [<modifier>] <combined_button_dictionary>": 
         #     R(Text('Key("%(modifier)s%(combined_button_dictionary)s")')),
 
+      
     }
+    
     tell_commands_dict = {"dock": ";", "doc": ";", "sink": "", "com": ",", "deck": ":"}
     tell_commands_dict.update(text_punc_dict)
 
@@ -324,14 +323,16 @@ class Navigation(MergeRule):
             "control windows alt shift": "cwas-",
             "hit": "", 
         })
+
+    
     extras = [
-        
+        Choice("enclosure", copy.deepcopy(enclosure)),
         IntegerRefST("nnavi10", 1, 11),
         IntegerRefST("nnavi3", 1, 4),
         IntegerRefST("nnavi50", 1, 50),
         IntegerRefST("nnavi500", 1, 500),
         Dictation("textnv"),
-        Choice("enclosure", double_text_punc_dict),
+        
         Choice("direction", {
             "dunce": "down",
             "sauce": "up",

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -236,7 +236,9 @@ class Navigation(MergeRule):
         "<word_limit> [<big>] format <textnv>":
             R(Function(textformat.partial_format_text)),
         "<enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
-            R(Function(enclose_format)),    
+            R(Function(enclose_format)),
+        "long <enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
+            R(Text(" ") + Function(enclose_format) + Text(" ")),    
         "hug <enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
             R(Function(enclose_format, hug=True)),
             # R(Function(text_utils.enclose_selected)),

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -232,17 +232,20 @@ class Navigation(MergeRule):
         "peek [<big>] format":
             R(Function(textformat.peek_text_format)),
        
-  
+
         # the next three commands put a space at the end
         "([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
             R(Function(enclose_format)), # combination enclosure, spacing, and capitalization command
-        "spay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
-            R(Text(" ") + Function(enclose_format)), # same as above, puts space at the beginning
+        "spay ([<enclosure>] [<capitalization>] [<spacing>] | [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] [<textnv>] [(brunt | over)]": 
+            R(Text(" ") + Function(enclose_format)), # same as above, but puts a space at the beginning
         "phrase <textnv> [(brunt | over)]": R(Function(enclose_format)), # mid utterance dictation command like "format"
         # the next four commands do not put a space at the end
-        "nay ([<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] <textnv> [(brunt | over)]": 
-            R(Function(enclose_format) + Key("backspace")), # combination enclosure, spacing, and capitalization command  
+        "nurk ([<enclosure>] [<capitalization>] [<spacing>] | [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] [<textnv>] [(brunt | over)]": 
+            R(Function(enclose_format) + Key("backspace")), # same combination command but no space at the end
+        "spurk ([<enclosure>] [<capitalization>] [<spacing>] | [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) | <enclosure> [<capitalization>] [<spacing>]) [bow] [<textnv>] [(brunt | over)]": 
+            R(Text(" ") + Function(enclose_format) + Key("backspace")), # same as above, but puts a space at the beginning
         "<enclosure>": R(Function(enclose_format)), # this is to e.g. type a pair of parentheses and put the cursor in between them
+        # to dictate in between enclosures and keep the cursor inside, say "<enclosure>" + "phrase <textnv>" which is a sequence of two commands
         "[<big>] format <textnv> [(brunt | over)]":
             R(Function(textformat.prior_text_format)),
         "<word_limit> [<big>] format <textnv> [(brunt | over)]":

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -235,20 +235,28 @@ class Navigation(MergeRule):
             R(Function(textformat.prior_text_format)),
         "<word_limit> [<big>] format <textnv>":
             R(Function(textformat.partial_format_text)),
-        "<enclosure> [<textnv>] [(over | brunt)]":
-            R(Function(enclose_format)),
-        "((<enclosure> [<capitalization>] [<spacing>]) | (<capitalization> <spacing> | <capitalization> | <spacing>)) [(bow|bowel)] <textnv> [brunt]": 
-            R(Function(enclose_format)),
-        "bound [<enclosure>] [<capitalization>] [<spacing>] [<textnv>] [brunt]":
-            R(Text(" ") + Function(enclose_format) + Text(" ")), 
-        "spay [<enclosure>] [<capitalization>] [<spacing>] <textnv> [brunt]":
-            R(Text(" ") + Function(enclose_format)), 
-        "skay [<enclosure>] [<capitalization>] [<spacing>] <textnv> [brunt]":
-            R(Function(enclose_format) + Text(" ")),    
-        "phrase <textnv> [brunt]": R(Function(enclose_format)),
         "hug <enclosure> [<capitalization>] [<spacing>]":
             R(Function(enclose_format, hug=True)),
-            # R(Function(text_utils.enclose_selected)),
+        "[<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) [(bow|bowel)] <textnv> [brunt]": 
+            R(Function(enclose_format)),
+        "bound [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) [<textnv>] [brunt]":
+            R(Text(" ") + Function(enclose_format) + Text(" ")), 
+        "spay [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) <textnv> [brunt]":
+            R(Text(" ") + Function(enclose_format)), 
+        "skay [<enclosure>] (<capitalization> <spacing> | <capitalization> | <spacing>) <textnv> [brunt]":
+            R(Function(enclose_format) + Text(" ")),    
+        # when inner_formatting=False, we can say "cap" to capitalize words within dictation.
+        # that is the purpose of the repeated commands below
+        "<enclosure> [<textnv>] [(over | brunt)]":
+            R(Function(enclose_format, inner_formatting=False)),
+        "bound [<enclosure>] [<textnv>] [brunt]":
+            R(Text(" ") + Function(enclose_format, inner_formatting=False) + Text(" ")), 
+        "spay [<enclosure>] <textnv> [brunt]":
+            R(Text(" ") + Function(enclose_format, inner_formatting=False)), 
+        "skay [<enclosure>] <textnv> [brunt]":
+            R(Function(enclose_format, inner_formatting=False) + Text(" ")),    
+        "phrase <textnv> [brunt]": R(Function(enclose_format, inner_formatting=False)),
+                   
 
         "dredge [<nnavi10>]":
             R(Key("alt:down, tab/20:%(nnavi10)d, alt:up"),

--- a/castervoice/lib/ccr/core/nav.py
+++ b/castervoice/lib/ccr/core/nav.py
@@ -235,9 +235,9 @@ class Navigation(MergeRule):
             R(Function(textformat.prior_text_format)),
         "<word_limit> [<big>] format <textnv>":
             R(Function(textformat.partial_format_text)),
-        "<enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
+        "(<enclosure> [<capitalization>] [<spacing>] | (<capitalization> | <spacing> | <capitalization> <spacing>)) [(bow|bowel)] [<textnv>] [(over | brunt)]":
             R(Function(enclose_format)),
-        "long <enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
+        "long [<enclosure>] [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
             R(Text(" ") + Function(enclose_format) + Text(" ")),    
         "hug <enclosure> [<capitalization>] [<spacing>] [(bow|bowel)] [<textnv>] [(over | brunt)]":
             R(Function(enclose_format, hug=True)),
@@ -407,6 +407,7 @@ class Navigation(MergeRule):
         "big": False,
         "splatdir": "backspace",
         "modifier": "",
+        "enclosure": "",
     }
 
 

--- a/castervoice/lib/ccr/core/punctuation.py
+++ b/castervoice/lib/ccr/core/punctuation.py
@@ -22,6 +22,7 @@ enclosure = {
     "curly": ("{","}"),
     "angle": ("<", ">"),
     "triple tick": ("```\n", "\n```"),
+    "varib": ("`<", ">`"),
     }
 
 def make_2tuple_into_string(input):

--- a/castervoice/lib/ccr/core/punctuation.py
+++ b/castervoice/lib/ccr/core/punctuation.py
@@ -7,17 +7,29 @@ from castervoice.lib.dfplus.merge.ccrmerger import CCRMerger
 from castervoice.lib.dfplus.merge.mergerule import MergeRule
 from castervoice.lib.dfplus.state.short import R
 
-double_text_punc_dict = {
-    "quotes":                            "\"\"",
-    "thin quotes":                         "''",
-    "tickris":                             "``",
-    "prekris":                             "()",
-    "brax":                                "[]",
-    "curly":                               "{}",
-    "angle":                               "<>",
-}
+enclosure = {
+    "quotes": "\"",
+    "thin quotes": "'",
+    "tickris": "`",
+    "dunder": "__",
+    "starry": "**",
+    "spacer": " ",
+    "dollz": "$",
+    "(bling | blinger)": "$$",
+    "prekris": ("(",")"),
+    "precoat": ("(\"", "\""),
+    "brax": ("[","]"),
+    "curly": ("{","}"),
+    "angle": ("<", ">"),
+    "triple tick": ("```\n", "\n```"),
+    }
 
-inv_dtpb = {v: k for k, v in double_text_punc_dict.iteritems()}
+def make_2tuple_into_string(input):
+    if isinstance(input, tuple):
+        return input[0] + input[1]
+    else:
+        return input
+inv_dtpb = {make_2tuple_into_string(v): k for k, v in enclosure.iteritems()}
 
 text_punc_dict = {
     "ace":                                                " ",
@@ -51,7 +63,7 @@ text_punc_dict = {
     "right " + inv_dtpb["[]"]:                            "]",
     "carrot":                                             "^",
     "underscore":                                         "_",
-    "ticky | ((left | right) " +  inv_dtpb["``"] + " )":  "`",
+    "ticky | ((left | right) " +  inv_dtpb["`"] + " )":  "`",
     "left " + inv_dtpb["{}"]:                             "{",
     "pipe (sim | symbol)":                                "|",
     "right " + inv_dtpb["{}"]:                            "}",
@@ -67,8 +79,7 @@ class Punctuation(MergeRule):
         # For some reason, this one doesn't work through the other function
         "[<long>] backslash [<npunc>]":
             R(Text("%(long)s" + "\\" + "%(long)s"))*Repeat(extra="npunc"),
-        "<double_text_punc> [<npunc>]":
-            R(Text("%(double_text_punc)s") + Key("left"))*Repeat(extra="npunc"),
+        
         "tabby [<npunc>]":
             R(Key("tab"))*Repeat(extra="npunc"),
         "(back | shin) tabby [<npunc>]":
@@ -90,8 +101,7 @@ class Punctuation(MergeRule):
             }),
         Choice(
             "text_punc", text_punc_dict),
-        Choice(
-            "double_text_punc", double_text_punc_dict)
+       
     ]
     defaults = {
         "npunc": 1,

--- a/castervoice/lib/imports.py
+++ b/castervoice/lib/imports.py
@@ -24,7 +24,7 @@ from castervoice.lib.dfplus.state.actions2 import UntilCancelled, NullAction, Bo
 from castervoice.lib.dfplus.state.short import L, S, R
 
 from castervoice.lib.ccr.standard import SymbolSpecs
-from castervoice.lib.ccr.core.punctuation import double_text_punc_dict, text_punc_dict
+from castervoice.lib.ccr.core.punctuation import enclosure, text_punc_dict
 
 import os, sys, re, copy, itertools, time
 import shutil, threading, subprocess, shlex

--- a/castervoice/lib/text_manipulation_functions.py
+++ b/castervoice/lib/text_manipulation_functions.py
@@ -4,7 +4,7 @@ import re
 import copy
 from dragonfly import Key, Pause, AppContext, Window
 from castervoice.lib import context
-from castervoice.lib.ccr.core.punctuation import text_punc_dict,  double_text_punc_dict
+from castervoice.lib.ccr.core.punctuation import text_punc_dict
 from castervoice.lib.alphanumeric import caster_alphabet
 
 

--- a/castervoice/lib/text_utils.py
+++ b/castervoice/lib/text_utils.py
@@ -36,17 +36,3 @@ def master_text_nav(mtn_mode, mtn_dir, nnavi500, extreme):
     time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
 
 
-def enclose_selected(enclosure):
-    ''' 
-    Encloses selected text in the appropriate enclosures
-    By using the system Clipboard as a buffer ( doesn't delete previous contents)
-    '''
-
-    (err, selected_text) = context.read_selected_without_altering_clipboard(True)
-    if err == 0:
-        opener = enclosure.split('~')[0]
-        closer = enclosure.split('~')[1]
-        enclosed_text = opener + selected_text + closer
-        # Attempt to paste enclosed text without altering clipboard
-        if not context.paste_string_without_altering_clipboard(enclosed_text):
-            print("failed to paste {}".format(enclosed_text))

--- a/castervoice/lib/textformat.py
+++ b/castervoice/lib/textformat.py
@@ -145,7 +145,7 @@ def master_format_text(capitalization, spacing, textnv):
     Text(TextFormat.formatted_text(capitalization, spacing, str(textnv))).execute()
 
 
-def enclose_format(enclosure, capitalization, spacing, textnv, hug=False, inner_formatting=True):
+def enclose_format(enclosure, capitalization, spacing, textnv, hug=False):
     if isinstance(enclosure, tuple):
         left_side, right_side = enclosure
     else:
@@ -164,6 +164,8 @@ def enclose_format(enclosure, capitalization, spacing, textnv, hug=False, inner_
         inner_text = TextFormat.formatted_text(capitalization, spacing, str(textnv))
         output_text = left_side + inner_text + right_side
         Text(output_text).execute()
-        # Alternate method: faster but not as reliable
-        # if not context.paste_string_without_altering_clipboard(enclosed_text):
-        #     print("failed to paste {}".format(enclosed_text))
+        if hug == False and textnv != "":
+            Text(" ").execute()
+
+
+

--- a/castervoice/lib/textformat.py
+++ b/castervoice/lib/textformat.py
@@ -71,10 +71,8 @@ class TextFormat():
 
     @classmethod
     def normalize_text_format(cls, capitalization, spacing):
-        # What is the purpose of this? I commented this out because it is causing
-        # problems when trying to use "cap" with dictation
-        # if capitalization == 0:
-        #     capitalization = 5
+        if capitalization == 0:
+            capitalization = 5
         if spacing == 0 and capitalization == 3:
             spacing = 1
         return (capitalization, spacing)
@@ -162,8 +160,13 @@ def enclose_format(enclosure, capitalization, spacing, textnv, hug=False, inner_
         offset = len(right_side)
         Key("left:%d" %offset).execute()
     else: # dictation has been provided
-        capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
-        inner_text = TextFormat.formatted_text(capitalization, spacing, str(textnv))
+        
+        if inner_formatting == True:
+            capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
+            inner_text = TextFormat.formatted_text(capitalization, spacing, str(textnv))
+        else:
+            inner_text = str(textnv)
+        
         output_text = left_side + inner_text + right_side
         Text(output_text).execute()
         # Alternate method: faster but not as reliable

--- a/castervoice/lib/textformat.py
+++ b/castervoice/lib/textformat.py
@@ -9,11 +9,17 @@ class TextFormat():
     Represents text formatting (capitalization and spacing) rules
 
     Commands for capitalization:
+    -1 rarb - capitals determined by Dragon vocabulary and by the use of the prefix "cap"
+        (ideally "cap" would override any capitalization commands by default but that is tricky 
+        so this is a temporary solution. it may not work perfectly with the "set format" command.) 
+    0 - (default) if word spacing is specified, then alllower (5), but
+        if word spacing is not specified, then capitals are determined by engine
+        vocabulary and by the use of the prefix "cap"
     1 yell - ALLCAPS
     2 tie - TitleCase
     3 Gerrish - camelCase
     4 sing - Sentencecase
-    5 laws (default) - alllower
+    5 laws - alllower
     Commands for word spacing:
     0 (default except Gerrish) - words with spaces
     1 gum (default for Gerrish)  - wordstogether
@@ -25,7 +31,7 @@ class TextFormat():
 
     @classmethod
     def formatted_text(cls, capitalization, spacing, t):
-        if capitalization != 0:
+        if capitalization != 0 and capitalization != -1:
             if capitalization == 1:
                 t = t.upper()
             elif capitalization == 2:
@@ -71,7 +77,11 @@ class TextFormat():
 
     @classmethod
     def normalize_text_format(cls, capitalization, spacing):
-        if capitalization == 0:
+        if capitalization == 0 and not spacing == 0:
+            # capitalization defaults to lower unless no spacing is provided
+            # in which case capitalization is determined by the engine vocabulary
+            # and by "cap" prefixes 
+            
             capitalization = 5
         if spacing == 0 and capitalization == 3:
             spacing = 1
@@ -134,17 +144,6 @@ def master_format_text(capitalization, spacing, textnv):
     capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
     Text(TextFormat.formatted_text(capitalization, spacing, str(textnv))).execute()
 
-# def cap_dictation(dictation):
-#     input_list = str(dictation).split(" ")
-#     print(input_list)
-#     output_list = []
-#     for i in range(len(input_list)):
-#         if input_list[i] == "cap":
-#             input_list[i + 1] = input_list[i + 1].title()
-#         else:
-#             output_list.append(input_list[i])
-    
-#     return " ".join(output_list) 
 
 def enclose_format(enclosure, capitalization, spacing, textnv, hug=False, inner_formatting=True):
     if isinstance(enclosure, tuple):
@@ -159,14 +158,10 @@ def enclose_format(enclosure, capitalization, spacing, textnv, hug=False, inner_
         Text(left_side + right_side).execute()
         offset = len(right_side)
         Key("left:%d" %offset).execute()
-    else: # dictation has been provided
+    else: # dictation has been provided 
         
-        if inner_formatting == True:
-            capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
-            inner_text = TextFormat.formatted_text(capitalization, spacing, str(textnv))
-        else:
-            inner_text = str(textnv)
-        
+        capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
+        inner_text = TextFormat.formatted_text(capitalization, spacing, str(textnv))
         output_text = left_side + inner_text + right_side
         Text(output_text).execute()
         # Alternate method: faster but not as reliable

--- a/castervoice/lib/textformat.py
+++ b/castervoice/lib/textformat.py
@@ -71,8 +71,10 @@ class TextFormat():
 
     @classmethod
     def normalize_text_format(cls, capitalization, spacing):
-        if capitalization == 0:
-            capitalization = 5
+        # What is the purpose of this? I commented this out because it is causing
+        # problems when trying to use "cap" with dictation
+        # if capitalization == 0:
+        #     capitalization = 5
         if spacing == 0 and capitalization == 3:
             spacing = 1
         return (capitalization, spacing)
@@ -134,12 +136,24 @@ def master_format_text(capitalization, spacing, textnv):
     capitalization, spacing = TextFormat.normalize_text_format(capitalization, spacing)
     Text(TextFormat.formatted_text(capitalization, spacing, str(textnv))).execute()
 
-def enclose_format(enclosure, capitalization, spacing, textnv, hug=False):
+# def cap_dictation(dictation):
+#     input_list = str(dictation).split(" ")
+#     print(input_list)
+#     output_list = []
+#     for i in range(len(input_list)):
+#         if input_list[i] == "cap":
+#             input_list[i + 1] = input_list[i + 1].title()
+#         else:
+#             output_list.append(input_list[i])
+    
+#     return " ".join(output_list) 
+
+def enclose_format(enclosure, capitalization, spacing, textnv, hug=False, inner_formatting=True):
     if isinstance(enclosure, tuple):
         left_side, right_side = enclosure
     else:
         left_side = enclosure; right_side = enclosure
-    if hug==True: # we are enclosing something that is already there
+    if hug == True: # we are enclosing something that is already there
         (err, selected_text) = context.read_selected_without_altering_clipboard(True)
         if err == 0:
             textnv = selected_text


### PR DESCRIPTION
## Description

This pull request allows you to say things like `"quotes <dictation>"` and puts the cursor at the end with a space. Other spacing options (e.g. before and/or after) are provided. The commands are in nav.py
It also combines this with the hug commands (e.g. for in enclosing something that is already there) and the formatting commands like snake (e.g. "hug quotes snake") . I removed the dictionary called `double_text_punc_dict` in favor of a more flexible dictionary called `enclosure` In punctuation.py.  the values of `enclosure` are either tuples representing the left and right boundaries of the enclosure or a single string which will occur on both the left and right side of the enclosure. I also add the ability to add spaces before and/or after dictation (enclosed and/or formatted or otherwise). Because functionality is consolidated, some old code is deleted. 

Note: it appears that the ability to say "cap" to get capitalization is now built into dragonfly `Dictation` objects?
I modified the capitalization/spacing commands a bit it so that you can capitalize words by prefixing with "cap"
This works with all the regular dictation commands but if you want to get that when using a spacing command like "snake" you must
preface "snake" with the word "rarb". ideally you wouldn't have to preface it that way but it's a tricky to 
get that without making considerable changes to the original capitalization/spacing functions.

I try to optimize the spacing defaults so for example a lot of things have a space afterwards but not the hug commands
and if you just say something like quotes, the cursor will be inside with no space. 
But the spacing is not perfect in every case. For example, saying something like "tickris angle hello" produces `"<hello> |"` (where the quotes are supposed to be backticks I just don't know how to escape them)
which is probably not what you want (where the bar represents the cursor). if you use, "tickris nurk angle hello", `"<hello>|"` is a bit better but you still want the cursor outside.
To solve this problem the user can create a new enclosure for this as I have already done and called it "varib" which produces the desired result `"<hello>" |` (again, I am using `"` instead of backticks because the escaping is tricky, but "variab" prints out backticks around angle brackets). 

Since all these commands basiccally run through the same function `enclose_format` in text_format.py, I made them all be printed out with the same method, namely text action.This is a change and that previously the hug commands used a clipboardd paste. There is a variable in the function `enclose_format` for whether a hug command is being used or not,so if desired it can be changed back to use the clipboard paste for hug commands.

It is possible that having all these different dictation commands or even just a couple with a bunch of different variables and optional arguments may slow down the recognition of these commands (but I don't think that's too much of an issue). 


<!-- Describe your changes in detail -->

## Motivation and Context
Without this you have to say things like `quotes format <dictation> ace arch`. now you can just say things like `quotes <dictation> arch`.   
<!-- Why is this change required? What problem does it solve? -->

## Possible future features
Ideally we would be able to have the ability to say something like "quotes arch brov long equals arch"
and have the cursor come out on the right side of the quotes without saying ross. 
This requires some kind of command recursion scheme which is something that caster probably should think more about anyways.
This can be accomplished using the underlying dragonfly API using Repetition objects, though I don't have a good understanding of it.
See the approach taken by @mrob95 in Mathfly for example (though there may be better ways)
[code](https://github.com/mrob95/mathfly/blob/master/mathfly/lib/merge/nestedrule.py) ,  [description](https://mathfly.org/implementation.html)
I might open issue about this at some point.

## How Has This Been Tested
I tested the commands and punctuation.py to make sure there is still work.
The new commands are all in nav.py . There are commands that just put a pair of punctuation marks `<enclosure>` 
and then there are commands that do dictation possibly with enclosures in her capitalization and/or spacing formatting
and/or outer spacing adjustment (e.g. before and/or after). I have tested various combinations of these.
My testing is in VS code if I see no bugs currently (though I may well have missed something).
Other editors may pose issues due to the auto pairing of punctuation. In writing these commands,
I did not take account of this auto pairing.  

### Bugs
I have found a bug when testing "tickris" in sublime
where unwanted single quotes are added when typing backticks. I don't know what to do about that. Within get markdown on Google Chrome, I once got the behavior where saying "prekris" but the cursor on the right of the parentheses instead of inside, but then that stopped happening I don't know why. 

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ x] Docs change recommended but not done
- [ x] New feature (non-breaking change which adds functionality)
- [x ] Breaking change: fix or feature that __could__ (but doesn't unless I made a mistake) cause existing functionality to change


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x ] I have read the CONTRIBUTING document.
- [ x] My code follows the code style of this project.
- [ x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [ x] My code implements all the features I wish to merge in this pull request.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
