### PR TITLE
Sets user directory with Permissions check with fallback location

### DIFF
--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -19,7 +19,9 @@ Thank you for using Caster!
 """
 
 SETTINGS = {}
-BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "lib", 1)[0].replace("\\", "/")
+BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "lib",
+                                              1)[0].replace("\\", "/")
+
 
 def set_user_dir():
     user_dir = 'empty_path'
@@ -33,13 +35,15 @@ def set_user_dir():
                 user_dir = directory
     except IOError as e:
         if e.errno == errno.EACCES:
-            print("Caster does not have read/write for a user directory. \n" + errno.EACCES)
+            print("Caster does not have read/write for a user directory. \n" +
+                  errno.EACCES)
     finally:
         if os.path.exists(user_dir):
             return user_dir
         else:
             print("Caster could not find a valid user directory at: " + str(user_dir))
             raise NameError('UserPathException')
+
 
 _USER_DIR = os.path.normpath(os.path.join(set_user_dir(), ".caster"))
 _SETTINGS_PATH = os.path.normpath(os.path.join(_USER_DIR, "/data/settings.toml"))

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -52,7 +52,7 @@ def set_user_dir():
 
 def validate_user_dir():
     '''
-    Checks for existing Caster's user directory path. Returns existing path.
+    Checks for existing Caster's user directory path. Returns path.
     '''
     user_dir = os.path.join(os.path.expanduser("~"), ".caster")
     if os.path.exists(user_dir) is True:

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -48,6 +48,8 @@ def set_user_dir():
 _USER_DIR = os.path.normpath(os.path.join(set_user_dir(), ".caster"))
 _SETTINGS_PATH = os.path.normpath(os.path.join(_USER_DIR, "/data/settings.toml"))
 
+print("Caster user directory: " + _USER_DIR)
+
 for directory in ["data", "rules", "filters", "sikuli"]:
     d = _USER_DIR + "/" + directory
     if not os.path.exists(d):

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -29,10 +29,11 @@ def set_user_dir():
         directory = os.path.expanduser("~")
         if os.access(directory, os.W_OK) and os.access(directory, os.R_OK) is True:
             user_dir = directory
-        if os.name == 'nt':
-            directory = os.path.expandvars(r'%APPDATA%')
-            if os.access(directory, os.W_OK) and os.access(directory, os.R_OK) is True:
-                user_dir = directory
+        else:
+            if os.name == 'nt':
+                directory = os.path.expandvars(r'%APPDATA%')
+                if os.access(directory, os.W_OK) and os.access(directory, os.R_OK) is True:
+                    user_dir = directory
     except IOError as e:
         if e.errno == errno.EACCES:
             print("Caster does not have read/write for a user directory. \n" +
@@ -44,9 +45,10 @@ def set_user_dir():
             print("Caster could not find a valid user directory at: " + str(user_dir))
             raise NameError('UserPathException')
 
+print(set_user_dir())
 
 _USER_DIR = os.path.normpath(os.path.join(set_user_dir(), ".caster"))
-_SETTINGS_PATH = os.path.normpath(os.path.join(_USER_DIR, "/data/settings.toml"))
+_SETTINGS_PATH = os.path.normpath(os.path.join(_USER_DIR, "data/settings.toml"))
 
 print("Caster user directory: " + _USER_DIR)
 

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -24,6 +24,9 @@ BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "lib",
 
 
 def set_user_dir():
+    '''
+    Sets Caster's user directory path. Returns "user_dir" with valid path for Home directory or AppData.
+    '''
     user_dir = 'empty_path'
     try:
         directory = os.path.expanduser("~")
@@ -32,7 +35,8 @@ def set_user_dir():
         else:
             if os.name == 'nt':
                 directory = os.path.expandvars(r'%APPDATA%')
-                if os.access(directory, os.W_OK) and os.access(directory, os.R_OK) is True:
+                if os.access(directory,
+                             os.W_OK) and os.access(directory, os.R_OK) is True:
                     user_dir = directory
     except IOError as e:
         if e.errno == errno.EACCES:
@@ -40,17 +44,33 @@ def set_user_dir():
                   errno.EACCES)
     finally:
         if os.path.exists(user_dir):
-            return user_dir
+            return os.path.normpath(os.path.join(user_dir, ".caster"))
         else:
             print("Caster could not find a valid user directory at: " + str(user_dir))
             raise NameError('UserPathException')
 
-print(set_user_dir())
 
-_USER_DIR = os.path.normpath(os.path.join(set_user_dir(), ".caster"))
+def validate_user_dir():
+    '''
+    Checks for existing Caster's user directory path. Returns existing path.
+    '''
+    user_dir = os.path.join(os.path.expanduser("~"), ".caster")
+    if os.path.exists(user_dir) is True:
+        return user_dir
+    if os.name == 'nt':
+        app_data = os.path.join(os.path.expandvars(r'%APPDATA%'), ".caster")
+        if os.path.exists(app_data) is True:
+            return app_data
+        else:
+            return set_user_dir()
+    else:
+        return set_user_dir()
+
+
+_USER_DIR = validate_user_dir()
 _SETTINGS_PATH = os.path.normpath(os.path.join(_USER_DIR, "data/settings.toml"))
 
-print("Caster user directory: " + _USER_DIR)
+print("Caster User Directory: " + _USER_DIR)
 
 for directory in ["data", "rules", "filters", "sikuli"]:
     d = _USER_DIR + "/" + directory


### PR DESCRIPTION
# Title
Sets user directory with Permissions check with Roaming fallback

## Description

Checks permissions for the `user directory` and uses `AppData\Roaming` as a fallback on Windows for the caster user profile.

## Related Issue
Reported issue in the gitter channel by @ethangoldstein 

## Motivation and Context

Due to restrictions IT managed devices permissions may be restricted in the user directory.  

## How Has This Been Tested

Tested by using invalid paths for user directory.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.


## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
