### PR TITLE
Find pip cross platform without environment variable

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -24,7 +24,7 @@ if settings.WSR:
 from castervoice.lib import control
 _NEXUS = control.nexus()
 _NEXUS.dep.initialize()
-from castervoice.lib.ctrl.dependencies import pip_path, update
+from castervoice.lib.ctrl.dependencies import find_pip, update
 from castervoice.lib import navigation
 navigation.initialize_clipboard(_NEXUS)
 
@@ -68,6 +68,7 @@ def change_monitor():
     else:
         print("This command requires SikuliX to be enabled in the settings file")
 
+pip = find_pip()
 
 class MainRule(MergeRule):
     @staticmethod
@@ -84,12 +85,13 @@ class MainRule(MergeRule):
             choices[ccr_choice] = ccr_choice
         return Choice("name2", choices)
 
+
     mapping = {
         # update management
         "update caster":
-            R(DependencyUpdate([pip_path, "install", "--upgrade", "castervoice"])),
+            R(DependencyUpdate([pip, "install", "--upgrade", "castervoice"])),
         "update dragonfly":
-            R(DependencyUpdate([pip_path, "install", "--upgrade", "dragonfly2"])),
+            R(DependencyUpdate([pip, "install", "--upgrade", "dragonfly2"])),
 
         # hardware management
         "volume <volume_mode> [<n>]":

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -11,6 +11,7 @@ from castervoice.lib import settings
 
 update = None
 
+
 def find_pip():
     # Find the pip script for Python.
     python_scripts = os.path.join(sys.exec_prefix, "Scripts")

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -4,24 +4,22 @@ Created on Oct 7, 2015
 @author: synkarius
 '''
 
-import os, socket, time, pkg_resources, subprocess
+import os, sys, socket, time, pkg_resources, subprocess
 from pkg_resources import VersionConflict, DistributionNotFound
 from subprocess import Popen
 from castervoice.lib import settings
 
-pip_path = None
 update = None
 
-
 def find_pip():
-    # Find the pip.exe script for Python 2.7. Fallback on pip.exe.
-    global pip_path
-    python_scripts = os.path.join("Python27", "Scripts")
-    for path in os.environ["PATH"].split(";"):
-        pip = os.path.join(path, "pip.exe")
-        if path.endswith(python_scripts) and os.path.isfile(pip):
-            pip_path = pip
-            break
+    # Find the pip script for Python.
+    python_scripts = os.path.join(sys.exec_prefix, "Scripts")
+    if sys.platform == "win32":
+        pip = os.path.join(python_scripts, "pip.exe")
+        return pip
+    if sys.platform == "linux" or "linux2":
+        pip = os.path.join(python_scripts, "pip")
+        return pip
 
 
 def install_type():
@@ -54,7 +52,7 @@ def internet_check(host="1.1.1.1", port=53, timeout=3):
 
 def dependency_check(command=None):
     # Check for updates pip packages castervoice/dragonfly2
-    com = [pip_path, "search", command]
+    com = [find_pip(), "search", command]
     startupinfo = None
     global update
     try:
@@ -132,7 +130,6 @@ class DependencyMan:
     # Initializes functions
     def initialize(self):
         install = install_type()
-        find_pip()
         if install is "classic":
             dep_min_version()
             dep_missing()


### PR DESCRIPTION
## Description

This pull request sys.exec_prefix to find pip or pip.exe path. 
@Versatilus partial credit goes to utilizing sys.exec_prefix which inspired this fix.

## Related Issue

@alexboche reported in gitter.

```
  | Exception from starting subprocess [None, 'search', 'dragonfly2']: argument of type 'NoneType' is not iterable
--|--
  | Error loading _caster from C:\Users\alex\Documents\Caster-master\_caster.py
  | Traceback (most recent call last):
  | File "C:\NatLink\NatLink\MacroSystem\core\natlinkmain.py", line 331, in loadFile
  | imp.load_module(modName,fndFile,fndName,fndDesc)
  | File "C:\Users\alex\Documents\Caster-master\_caster.py", line 72, in <module>
  | class MainRule(MergeRule):
  | File "C:\Users\alex\Documents\Caster-master\_caster.py", line 90, in MainRule
  | R(DependencyUpdate([pip_path, "install", "--upgrade", "castervoice"])),
  | File "C:\Python27\lib\site-packages\dragonfly\actions\action_cmd.py", line 168, in __init__
  | self._str = "'%s'" % " ".join(self.command)
  | TypeError: sequence item 0: expected string, NoneType found
```

## Motivation and Context

`sys.exec_prefix` to find pip or pip.exe path instead of relying on windows environmental variable Python path. action_cmd without the path for PIP leading to above error. In addition this function is cross-platform. 

## How Has This Been Tested

- [x] This has been tested by removing the Python path from windows environmental variables then restarting Windows. 
- [x] function tested on linux.
- [x] function tested on Python 3.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [x]  All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] Code is clear and readable.
