### PR TITLE
# Switch mouse commands to use standard cancel phrase

### DIFF
--- a/castervoice/apps/griddouglas.py
+++ b/castervoice/apps/griddouglas.py
@@ -70,7 +70,7 @@ class DouglasGridRule(MergeRule):
             R(Function(store_first_point)),
         "bench":
             R(Function(select_text, nexus=_NEXUS)),
-        "exit | escape | cancel":
+        SymbolSpecs.CANCEL:
             R(Function(kill, nexus=_NEXUS)),
     }
     extras = [

--- a/castervoice/apps/gridlegion.py
+++ b/castervoice/apps/gridlegion.py
@@ -69,7 +69,7 @@ class LegionGridRule(MergeRule):
             R(Function(send_input, nexus=_NEXUS)),
         "refresh":
             R(Function(navigation.mouse_alternates, mode="legion", nexus=_NEXUS)),
-        "exit | escape | cancel":
+        SymbolSpecs.CANCEL:
             R(Function(kill, nexus=_NEXUS)),
         "<n1> (select | light) <n2>":
             R(Function(drag_highlight, nexus=_NEXUS)),

--- a/castervoice/apps/gridrainbow.py
+++ b/castervoice/apps/gridrainbow.py
@@ -72,7 +72,7 @@ class RainbowGridRule(MergeRule):
             R(Function(store_first_point)),
         "bench":
             R(Function(select_text, nexus=_NEXUS)),
-        "exit | escape | cancel":
+        SymbolSpecs.CANCEL:
             R(Function(kill, nexus=_NEXUS)),
     }
     extras = [

--- a/castervoice/lib/ccr/standard.py
+++ b/castervoice/lib/ccr/standard.py
@@ -45,7 +45,7 @@ class SymbolSpecs(object):
     FALSE = "value false"
 
     # not part of the programming standard:
-    CANCEL = "(terminate | escape)"
+    CANCEL = "(terminate | escape | exit | cancel)"
 
     @staticmethod
     def set_cancel_word(spec):


### PR DESCRIPTION
## Description

In each of `griddouglas.py`, `gridrainbow.py`, and `gridlegion.py` I replace the cancel phrase/spec with `SymbolSpecs.CANCEL`. I also added the options `exit | cancel` to `SymbolSpeaks.CANCEL` so that this is not a breaking change.

## Related Issue

None.

## Motivation and Context

The cancel phrase should be the same throughout for each user and they should only have to change the phrase in one place. 

## How Has This Been Tested

No testing as yet as this is a simple change.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly (N/A).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete (N/A).
- [x] Code is clear and readable.