### PR TITLE
OS/Caster profile agnostic BringMe default file paths 

### DIFF
--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -64,7 +64,7 @@ class BringRule(SelfModifyingRule):
                 (self.explorer_context, Key("c-l/5") + Text("%s\n" % folder))
             ]).execute()
         elif app == "terminal":
-            Popen([self.terminal_path, "--cd=" + folder.replace("\\", "/")])
+            Popen([self.terminal_path, "--cd=" + os.path.normpath(folder)])
         elif app == "explorer":
             Popen([self.explorer_path, folder])
 

--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -4,6 +4,7 @@ from castervoice.apps.gitbash import terminal_context
 from castervoice.apps.file_dialogue import dialogue_context
 from castervoice.lib import settings
 
+
 class BringRule(SelfModifyingRule):
     pronunciation = "bring me"
 
@@ -83,10 +84,10 @@ class BringRule(SelfModifyingRule):
                 print("Program path for bring me not found ")
         elif launch == 'file':
             files = utilities.get_selected_files(folders=False)
-            path = files[0] if files else None # or allow adding multiple files
+            path = files[0] if files else None  # or allow adding multiple files
         elif launch == 'folder':
             files = utilities.get_selected_files(folders=True)
-            path = files[0] if files else None # or allow adding multiple folders
+            path = files[0] if files else None  # or allow adding multiple folders
         else:
             Key("a-d/5").execute()
             fail, path = context.read_selected_without_altering_clipboard()
@@ -155,10 +156,9 @@ class BringRule(SelfModifyingRule):
         if not startup:
             self.refresh()
 
+    userdir = settings.SETTINGS["paths"]["USER_DIR"]  # Caster User Directory
+    osuserdir = path.expanduser("~")  # OS User directory
 
-    userdir = settings.SETTINGS["paths"]["USER_DIR"] # Caster User Directory
-    osuserdir = path.expanduser("~") # OS User directory
-    
     bm_defaults = {
         "website": {
             "caster documentation": "https://caster.readthedocs.io/en/latest/",
@@ -172,25 +172,24 @@ class BringRule(SelfModifyingRule):
             "libraries": path.expanduser("~"),
             "my pictures": path.join(osuserdir, "Pictures"),
             "my documents": path.join(osuserdir, "Documents"),
-            "caster user":  userdir,
+            "caster user": userdir,
             "caster filters": path.join(userdir, "filters"),
-            "caster rules":  path.join(userdir, "rules"),
-            "caster data":  path.join(userdir, "data"),
-            "sick you lee":  path.join(userdir, "sikuli"),
+            "caster rules": path.join(userdir, "rules"),
+            "caster data": path.join(userdir, "data"),
+            "sick you lee": path.join(userdir, "sikuli"),
         },
         "program": {
             "notepad": "C:\\Windows\\notepad.exe",
         },
         "file": {
-            "caster settings":  path.normpath(path.join(userdir, "data\\settings.toml")),
-            "caster alias":  path.normpath(path.join(userdir, "data\\aliases.toml")),
-            "caster bring me":  path.normpath(path.join(userdir, "data\\bringme.toml")),
+            "caster settings": path.normpath(path.join(userdir, "data\\settings.toml")),
+            "caster alias": path.normpath(path.join(userdir, "data\\aliases.toml")),
+            "caster bring me": path.normpath(path.join(userdir, "data\\bringme.toml")),
             "caster ccr":  path.normpath(path.join(userdir, "data\\ccr.toml")),
-            "caster config debug":  path.normpath(path.join(userdir, "data\\configdebug.txt")),
-            "caster words":  path.normpath(path.join(userdir, "filter\\words.txt")),
-            "caster log":  path.normpath(path.join(userdir, "data\\log.txt")),
+            "caster config debug": path.normpath(path.join(userdir, "data\\configdebug.txt")),
+            "caster words": path.normpath(path.join(userdir, "filter\\words.txt")),
+            "caster log": path.normpath(path.join(userdir, "data\\log.txt")),
         }
     }
-
 
 control.non_ccr_app_rule(BringRule(), context=None, rdp=False, filter=True)

--- a/castervoice/lib/ccr/recording/bringme.py
+++ b/castervoice/lib/ccr/recording/bringme.py
@@ -1,7 +1,8 @@
+import os.path as path
 from castervoice.lib.imports import *
 from castervoice.apps.gitbash import terminal_context
 from castervoice.apps.file_dialogue import dialogue_context
-
+from castervoice.lib import settings
 
 class BringRule(SelfModifyingRule):
     pronunciation = "bring me"
@@ -154,6 +155,10 @@ class BringRule(SelfModifyingRule):
         if not startup:
             self.refresh()
 
+
+    userdir = settings.SETTINGS["paths"]["USER_DIR"] # Caster User Directory
+    osuserdir = path.expanduser("~") # OS User directory
+    
     bm_defaults = {
         "website": {
             "caster documentation": "https://caster.readthedocs.io/en/latest/",
@@ -164,26 +169,26 @@ class BringRule(SelfModifyingRule):
             "google": "https://www.google.com",
         },
         "folder": {
-            "libraries": "%USERPROFILE%",
-            "my pictures": "%USERPROFILE%\\Pictures",
-            "my documents": "%USERPROFILE%\\Documents",
-            "caster user": "%USERPROFILE%\\.caster",
-            "caster filters": "%USERPROFILE%\\.caster\\filters",
-            "caster rules": "%USERPROFILE%\\.caster\\rules",
-            "caster data": "%USERPROFILE%\\.caster\\data",
-            "sick you lee": "%USERPROFILE%\\.caster\\sikuli",
+            "libraries": path.expanduser("~"),
+            "my pictures": path.join(osuserdir, "Pictures"),
+            "my documents": path.join(osuserdir, "Documents"),
+            "caster user":  userdir,
+            "caster filters": path.join(userdir, "filters"),
+            "caster rules":  path.join(userdir, "rules"),
+            "caster data":  path.join(userdir, "data"),
+            "sick you lee":  path.join(userdir, "sikuli"),
         },
         "program": {
             "notepad": "C:\\Windows\\notepad.exe",
         },
         "file": {
-            "caster settings": "%USERPROFILE%\\.caster\\data\\settings.toml",
-            "caster alias": "%USERPROFILE%\\.caster\\data\\aliases.toml",
-            "caster bring me": "%USERPROFILE%\\.caster\\data\\bringme.toml",
-            "caster ccr": "%USERPROFILE%\\.caster\\data\\ccr.toml",
-            "caster config debug": "%USERPROFILE%\\.caster\\data\\configdebug.txt",
-            "caster words": "%USERPROFILE%\\.caster\\filter\\words.txt",
-            "caster log": "%USERPROFILE%\\.caster\\data\\log.txt",
+            "caster settings":  path.normpath(path.join(userdir, "data\\settings.toml")),
+            "caster alias":  path.normpath(path.join(userdir, "data\\aliases.toml")),
+            "caster bring me":  path.normpath(path.join(userdir, "data\\bringme.toml")),
+            "caster ccr":  path.normpath(path.join(userdir, "data\\ccr.toml")),
+            "caster config debug":  path.normpath(path.join(userdir, "data\\configdebug.txt")),
+            "caster words":  path.normpath(path.join(userdir, "filter\\words.txt")),
+            "caster log":  path.normpath(path.join(userdir, "data\\log.txt")),
         }
     }
 


### PR DESCRIPTION
<!-- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.-->

## Description

Alternate user directory breaks the bring me feature. OS/Caster agnostic BringMe default file paths 
**Note** this currently does not address OS specific internal BringMe paths. Only user facing defaults.

## Related Issue

<!-- Please reference any related issues here -->
Resolves https://github.com/dictation-toolbox/Caster/issues/677
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Allows for Caster User profile alternate locations
Eliminating OS specific environmental variables. Nudges to bring me feature closer to being Cross-platform,

## How Has This Been Tested

Deleting and regenerating bringme.toml
Tested in the default user directory location and alternate

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade (re-factor)
- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My code implements all the features I wish to merge in this pull request.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.


@mrob95 if you have time to review this that would be great.