### PR TITLE
remove unneeded itertools import (trivial)

### DIFF
--- a/castervoice/lib/text_manipulation_functions.py
+++ b/castervoice/lib/text_manipulation_functions.py
@@ -1,4 +1,3 @@
-import itertools
 import pyperclip
 import re 
 import copy


### PR DESCRIPTION
# Title
Trivial change:

## Description
Remove unneeded itertools import at the top of text_manipulation_functions.py
I used itertools previously in this file before I found out about Repetition objects. itertools has not been used in this file for months.
