### PR TITLE
[Trivial change]  Docs CI are passing but ReadTheDocs badge fails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,5 @@
 # Caster
-[![Travis Build Status](https://travis-ci.org/dictation-toolbox/Caster.svg?branch=master)](https://travis-ci.org/dictation-toolbox/Caster) [![ReadTheDocs Build Status](https://readthedocs.org/projects/pip/badge/)](https://caster.readthedocs.io/en/latest/)
-
+[![Travis Build Status](https://travis-ci.org/dictation-toolbox/Caster.svg?branch=master)](https://travis-ci.org/dictation-toolbox/Caster) [![Documentation Status](https://readthedocs.org/projects/caster/badge/?version=latest)](https://caster.readthedocs.io/en/latest/?badge=latest)
 [Caster](https://github.com/dictation-toolbox/Caster)  is a collection of tools aimed at enabling programming and accessibility entirely by voice built upon the [Dragonfly](https://github.com/dictation-toolbox/dragonfly) API.
 
 **Note for PyPi Users**: The PIP package is (_Alpha_). Do not use the PIP install. Alternatively use this [Master Branch](https://github.com/dictation-toolbox/Caster) with classic install for the best feature experience.


### PR DESCRIPTION
Edit: Looks like the badge updated with passing on its own, however the URL still could be updated.

## Description

False positive for failing ReadTheDocs CI due to out of date badge.

## Types of changes

Fixed by updating the ReadTheDocs badge

<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [x] New documentation is clear and complete.
