### PR TITLE
Upon error in Status Window will come to the forefront.

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -3,10 +3,12 @@
 main Caster module
 Created on Jun 29, 2014
 '''
-
+import datetime
 import logging
-logging.basicConfig()
 from dragonfly import get_engine
+from dragonfly.windows.window import Window
+
+logging.basicConfig(format = "%(asctime)s")  
 
 from castervoice.lib import settings  # requires toml
 settings.initialize()
@@ -14,6 +16,24 @@ settings.initialize()
 from castervoice.lib.ctrl.dependencies import DependencyMan  # requires nothing
 DependencyMan().initialize()
 _NEXUS = None
+
+class LoggingHandler(logging.Handler):
+    def emit(self, record):
+        msg = self.format(record)
+        print("\n")
+        # Brings status window to the forefront upon error
+        if (settings.SETTINGS["miscellaneous"]["status_window_forefront_on_error"]):
+             # The window title is unique to Natlink
+            if (get_engine()._name == 'natlink'):
+                windows = Window.get_matching_windows(None, "Messages from Python Macros V")
+            if windows:
+                windows[0].set_foreground()
+
+logger1 = logging.getLogger('action')
+logger1.addHandler(LoggingHandler())
+
+logger2 = logging.getLogger('engine')
+logger2.addHandler(LoggingHandler())
 
 # Natlink with DNS requires 32-bit Python and Windows OS
 # ToDo: create then move to castervoice.lib.ctrl.engines

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -424,7 +424,8 @@ def _get_defaults():
             "use_aenea": False,
             "hmc": True,
             "ccr_on": True,
-            "reload_trigger": "timer"
+            "reload_trigger": "timer",
+            "status_window_forefront_on_error": False,
         },
 
         "formats": {


### PR DESCRIPTION
## Description

90% of the credit for this goes to @lettersandnumbersgithub. All I did was make it conditional in settings and based on engine type. 

Upon error status window will come to the forefront. Configurable `settings.toml` under `miscellaneous` "status_window_forefront_on_error" with Bool. Default set to false.

Note: Errors during initial caster startup do not bring the window to the forefront.

## Related Issue

none

## Motivation and Context

Often when working status window is in the foreground behind other windows. Think of the following scenarios.
- If an error occurs the user may not be aware of it leading to confusion.
- The user may want to check for an Error but has to manually bring the status window to the forefront

For reference status window
![image](https://user-images.githubusercontent.com/24551569/70479985-325aed80-1aa4-11ea-800a-7a0e99e65080.png)


## How Has This Been Tested

It is been tested to ensure the "status_window_forefront_on_error" are functional.
Tested with errors during startup and after.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.
