### PR TITLE
Fix missing repeats in the sublime edit up/down/next commands

### DIFF
--- a/castervoice/rules/apps/editor/sublime.py
+++ b/castervoice/rules/apps/editor/sublime.py
@@ -1,4 +1,4 @@
-from dragonfly import Function, Dictation, Choice, MappingRule
+from dragonfly import Function, Dictation, Choice, MappingRule,Repeat
 
 from castervoice.lib import navigation
 from castervoice.lib.actions import Key, Text
@@ -52,12 +52,12 @@ class SublimeRule(MappingRule):
         "edit lines":
             R(Key("cs-l")),
         "edit next [<n3>]":
-            R(Key("c-d/10")),
+            R(Key("c-d/10"))*Repeat(extra="n3"),
         "edit up [<n3>]":
-            R(Key("ac-up")),
+            R(Key("ac-up"))*Repeat(extra="n3"),
         "edit down [<n3>]":
-            R(Key("ac-down")),
-        "edit all":
+            R(Key("ac-down"))*Repeat(extra="n3"),
+       "edit all":
             R(Key("a-f3")),
         #
         "transform upper":


### PR DESCRIPTION
# Title

Fix missing repeats in the sublime edit up/down/next commands

## Description

Fix missing repeats in the sublime edit up/down/next commands and import Repeat from dragonfly





## Motivation and Context

In the newest version of Caster , In the sublime Grammar , the commands that should enable creating multiple coursers in the lines above or below the current one were missing their repeat action which caused them to behave as if the extra parameter was always one:

![bug1](https://user-images.githubusercontent.com/35875229/71270801-23552480-235b-11ea-99d6-e90c53161788.gif)

As a consequence, only adjacent lines could be edited simultaneously.

## How Has This Been Tested

Manual testing, After changes:

![bug2](https://user-images.githubusercontent.com/35875229/71271742-1422a680-235c-11ea-9731-7f881aca02ac.gif)


## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist


- [ ] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [ ] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [ ] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.
