### PR TITLE
Pr settings window bandaid

### DIFF
--- a/castervoice/asynch/settingswindow.py
+++ b/castervoice/asynch/settingswindow.py
@@ -6,7 +6,7 @@ import sys
 import threading
 from SimpleXMLRPCServer import SimpleXMLRPCServer
 from threading import Timer
-import tomlkit
+import numbers
 
 try:  # Style C -- may be imported into Caster, or externally
     BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "castervoice", 1)[0]
@@ -40,7 +40,6 @@ STRING_LIST_SETTING = 4
 NUMBER_LIST_SETTING = 8
 NUMBER_SETTING = 16
 BOOLEAN_SETTING = 32
-real_type = (tomlkit.items.Integer, tomlkit.items.Float, float, int)
 
 class Field:
     def __init__(self, wx_field, original, text_type=None):
@@ -191,13 +190,13 @@ class SettingsFrame(Frame):
             if isinstance(value[0], basestring):
                 item = TextCtrl(window, value=", ".join(value))
                 field.text_type = STRING_LIST_SETTING
-            elif isinstance(value[0], real_type):
+            elif isinstance(value[0], numbers.Real):
                 item = TextCtrl(window, value=", ".join((str(x) for x in value)))
                 field.text_type = NUMBER_LIST_SETTING
         elif isinstance(value, bool):
             item = CheckBox(window, -1, '', (120, 75))
             item.SetValue(value)
-        elif isinstance(value, real_type):
+        elif isinstance(value, numbers.Real):
             item = TextCtrl(window, value=str(value))
             field.text_type = NUMBER_SETTING
         elif isinstance(value, dict):


### PR DESCRIPTION
# Fixes #723

## Description

It works in that it doesn't outright crash, but it's still ugly/glitchy.

The crash was due to the way settings initialization changed a few months ago. Once the settings were properly initialized, I was able to start the script normally.

Once I was successfully able to launch the settings window I discovered that all of the input elements for numbers were missing. This was due to an additional bug in the settings parsing code which was introduced with the switch `tomlkit`. The numbers were being passed over during window startup because `tomlkit` uses its own classes to represent real numbers. I changed the instance check to test against the built-in `numbers.Real` instead of `int`. This change is kind of minimal and hacky, but the proper changes would be quite extensive.

Ultimately, this application should be more or less totally rebuilt to account for the large number of changes the code base has experienced over the years.

## How Has This Been Tested

Quite frankly, it hasn't been. This is a stopgap fix until someone gets around to rebuilding the whole script.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code implements all the features I wish to merge in this pull request.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.