### PR TITLE
Bug fix: multi-clipboard wasn't initialized.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ caster/bin/data
 
 # Ignore dist files
 dist
+build/
 castervoice.egg-info
 /.stignore
 

--- a/castervoice/lib/navigation.py
+++ b/castervoice/lib/navigation.py
@@ -26,6 +26,9 @@ def initialize_clipboard():
             settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
 
 
+initialize_clipboard()
+
+
 def mouse_alternates(mode, monitor=1):
     if mode == "legion" and not utilities.window_exists(None, "legiongrid"):
         r = monitors[int(monitor) - 1].rectangle

--- a/castervoice/lib/navigation.py
+++ b/castervoice/lib/navigation.py
@@ -23,7 +23,7 @@ def initialize_clipboard():
     global _CLIP
     if len(_CLIP) == 0:
         _CLIP = utilities.load_json_file(
-            settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+            settings.settings(["paths", "SAVED_CLIPBOARD_PATH"]))
 
 
 initialize_clipboard()
@@ -42,26 +42,26 @@ def mouse_alternates(mode, monitor=1):
         ls.scan(bbox)
         tscan = ls.get_update()
         Popen([
-            settings.SETTINGS["paths"]["PYTHONW"],
-            settings.SETTINGS["paths"]["LEGION_PATH"], "-t", tscan[0], "-m",
+            settings.settings(["paths","PYTHONW"]),
+            settings.settings(["paths","LEGION_PATH"]), "-t", tscan[0], "-m",
             str(monitor)
         ])
     elif mode == "rainbow" and not utilities.window_exists(None, "rainbowgrid"):
         Popen([
-            settings.SETTINGS["paths"]["PYTHONW"],
-            settings.SETTINGS["paths"]["RAINBOW_PATH"], "-g", "r", "-m",
+            settings.settings(["paths","PYTHONW"]),
+            settings.settings(["paths","RAINBOW_PATH"]), "-g", "r", "-m",
             str(monitor)
         ])
     elif mode == "douglas" and not utilities.window_exists(None, "douglasgrid"):
         Popen([
-            settings.SETTINGS["paths"]["PYTHONW"],
-            settings.SETTINGS["paths"]["DOUGLAS_PATH"], "-g", "d", "-m",
+            settings.settings(["paths","PYTHONW"]),
+            settings.settings(["paths","DOUGLAS_PATH"]), "-g", "d", "-m",
             str(monitor)
         ])
     elif mode == "sudoku" and not utilities.window_exists(None, "sudokugrid"):
         Popen([
-            settings.SETTINGS["paths"]["PYTHONW"],
-            settings.SETTINGS["paths"]["SUDOKU_PATH"], "-g", "s", "-m",
+            settings.settings(["paths","PYTHONW"]),
+            settings.settings(["paths","SUDOKU_PATH"]), "-g", "s", "-m",
             str(monitor)
         ])
 
@@ -80,10 +80,10 @@ def _text_to_clipboard(keystroke, nnavi500):
             try:
                 # time for keypress to execute
                 time.sleep(
-                    settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+                    settings.settings([u'miscellaneous', u'keypress_wait'])/1000.)
                 _CLIP[key] = unicode(Clipboard.get_system_text())
                 utilities.save_json_file(
-                    _CLIP, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+                    _CLIP, settings.settings([u'paths', u'SAVED_CLIPBOARD_PATH']))
             except Exception:
                 failure = True
                 utilities.simple_log()
@@ -122,9 +122,9 @@ def drop_keep_clipboard(nnavi500, capitalization, spacing):
             text = textformat.TextFormat.formatted_text(
                 capitalization, spacing, text)
         Clipboard.set_system_text(text)
-        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        time.sleep(settings.settings([u'miscellaneous', u'keypress_wait'])/1000.)
         Key("c-v").execute()
-        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        time.sleep(settings.settings([u'miscellaneous', u'keypress_wait'])/1000.)
         # Restore the clipboard contents.
         cb.copy_to_system()
 
@@ -132,10 +132,10 @@ def drop_keep_clipboard(nnavi500, capitalization, spacing):
 def duple_keep_clipboard(nnavi50):
     cb = Clipboard(from_system=True)
     Key("escape, home, s-end, c-c, end").execute()
-    time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+    time.sleep(settings.settings([u'miscellaneous', u'keypress_wait'])/1000.)
     for i in range(0, nnavi50):
         Key("enter, c-v").execute()
-        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        time.sleep(settings.settings([u'miscellaneous', u'keypress_wait'])/1000.)
     cb.copy_to_system()
 
 
@@ -143,7 +143,7 @@ def erase_multi_clipboard():
     global _CLIP
     _CLIP = {}
     utilities.save_json_file(_CLIP,
-                             settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+                             settings.settings([u'paths', u'SAVED_CLIPBOARD_PATH']))
 
 
 def volume_control(n, volume_mode):

--- a/tests/test_util/utilities_mocking.py
+++ b/tests/test_util/utilities_mocking.py
@@ -20,3 +20,5 @@ def mock_toml_files():
     _TOML_FILE = {}
     utilities.save_toml_file = _save_toml_file
     utilities.load_toml_file = _load_toml_file
+    utilities.save_json_file = _save_toml_file
+    utilities.load_json_file = _load_toml_file

--- a/tests/testrunner.py
+++ b/tests/testrunner.py
@@ -6,7 +6,7 @@ from dragonfly import get_engine
 
 from castervoice.lib.ctrl.mgr.errors.guidance_rejection import GuidanceRejectionException
 from castervoice.lib.util import guidance
-from tests.test_util import settings_mocking
+from tests.test_util import settings_mocking, utilities_mocking
 
 
 def reject_file_writing():
@@ -20,6 +20,7 @@ def get_master_suite():
 def run_tests():
     get_engine("text")
     settings_mocking.prevent_initialize()
+    utilities_mocking.mock_toml_files()
     return unittest.TextTestRunner(verbosity=2).run(get_master_suite())
 
 


### PR DESCRIPTION
# Trivial change

Fixed a bug where the multi-clipboard was being erased whenever it was **pasted from** before being **copied into**. This was due to failing to initialize the multi-clipboard on module load.

Initialization was segregated into a function during a refactor but that function was never called.


