### PR TITLE
Initialized update_check after settings

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -10,11 +10,15 @@ from dragonfly.windows.window import Window
 
 logging.basicConfig(format = "%(asctime)s : %(levelname)s : %(funcName)s\n%(msg)s")   
 
-from castervoice.lib import settings  # requires toml
-settings.initialize()
-
 from castervoice.lib.ctrl.dependencies import DependencyMan  # requires nothing
 DependencyMan().initialize()
+
+from castervoice.lib import settings  
+settings.initialize()
+
+from castervoice.lib.ctrl.updatecheck import UpdateChecker # requires settings/dependencies
+UpdateChecker().initialize()
+
 _NEXUS = None
 
 class LoggingHandler(logging.Handler):

--- a/_caster.py
+++ b/_caster.py
@@ -5,8 +5,6 @@ Created on Jun 29, 2014
 '''
 import datetime
 import logging
-from dragonfly import get_engine
-from dragonfly.windows.window import Window
 
 logging.basicConfig(format = "%(asctime)s : %(levelname)s : %(funcName)s\n%(msg)s")   
 
@@ -18,6 +16,10 @@ settings.initialize()
 
 from castervoice.lib.ctrl.updatecheck import UpdateChecker # requires settings/dependencies
 UpdateChecker().initialize()
+
+from dragonfly import get_engine
+from dragonfly.windows.window import Window
+
 
 _NEXUS = None
 

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -42,7 +42,7 @@ def dep_missing():
         except VersionConflict:
             pass
         except DistributionNotFound as e:
-            print("\n Caster: {0} dependency is missing. Use 'pip install {0}' in CMD or Terminal to install"
+            print("\n Caster: {0} dependency is missing. Use 'python -m pip install {0}' in CMD or Terminal to install"
                   .format(e.req))
             time.sleep(15)
 
@@ -84,8 +84,8 @@ class DependencyMan:
     def initialize(self):
         install = install_type()
         if install is "classic":
-            dep_min_version()
             dep_missing()
+            dep_min_version()
 
     NATLINK = True
     PYWIN32 = True

--- a/castervoice/lib/ctrl/dependencies.py
+++ b/castervoice/lib/ctrl/dependencies.py
@@ -3,23 +3,8 @@ Created on Oct 7, 2015
 
 @author: synkarius
 '''
-import os, sys, socket, time, pkg_resources, subprocess
+import os, sys, time, pkg_resources
 from pkg_resources import VersionConflict, DistributionNotFound
-from datetime import datetime, date
-
-update = None
-
-
-def find_pip():
-    # Find the pip script for Python.
-    python_scripts = os.path.join(sys.exec_prefix, "Scripts")
-    if sys.platform == "win32":
-        pip = os.path.join(python_scripts, "pip.exe")
-        return pip
-    if sys.platform.startswith("linux"):
-        pip = os.path.join(python_scripts, "pip")
-        return pip
-    return None
 
 
 def install_type():
@@ -33,55 +18,16 @@ def install_type():
     return "pip"
 
 
-def internet_check(host="1.1.1.1", port=53, timeout=3):
-    """
-    Checks for network connection via DNS resolution.
-    :param host: CloudFire DNS
-    :param port: 53/tcp
-    :param timeout: An integer
-    :return: True or False
-    """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.settimeout(timeout)
-        s.connect((host, port))
-        return True
-    except socket.error as e:
-        if e.errno == 11001:
-            print("Caster: Internet check failed to resolve CloudFire DNS")
-        if e.errno == 10051:  # Unreachable Network
-            pass
-        if e.errno not in (10051, 11001):  # Unknown Error
-            print(e.errno)
-        return False
-
-
-def dependency_check(command=None):
-    # Check for updates pip packages castervoice/dragonfly2
-    com = ["python", "-m", find_pip(), "search", command]
-    startupinfo = None
-    global update
-    try:
-        if os.name == 'nt':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        p = subprocess.Popen(com,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             stdin=subprocess.PIPE,
-                             startupinfo=startupinfo)
-        out = p.communicate('')
-        for line in out:
-            if "INSTALLED" and "latest" in line:
-                print("Caster: {0} is up-to-date".format(command.strip('2')))
-                update = False
-                break
-            else:
-                print("Caster: Say 'Update {0}' to update.".format(command.strip('2')))
-                update = True
-                break
-    except Exception as e:
-        print("Exception from starting subprocess {0}: " "{1}".format(com, e))
+def find_pip():
+    # Find the pip script for Python.
+    python_scripts = os.path.join(sys.exec_prefix, "Scripts")
+    if sys.platform == "win32":
+        pip = os.path.join(python_scripts, "pip.exe")
+        return pip
+    if sys.platform.startswith("linux"):
+        pip = os.path.join(python_scripts, "pip")
+        return pip
+    return None
 
 
 def dep_missing():
@@ -97,7 +43,7 @@ def dep_missing():
             pass
         except DistributionNotFound as e:
             print("\n Caster: {0} dependency is missing. Use 'pip install {0}' in CMD or Terminal to install"
-                .format(e.req))
+                  .format(e.req))
             time.sleep(15)
 
 
@@ -122,7 +68,7 @@ def dep_min_version():
             if operator is "==":
                 print(
                     "\nCaster: Requires an exact version of dependencies. Issue reference: {0} \n"
-                    .format(issueurl))
+                        .format(issueurl))
                 print("Install the exact version: 'python -m pip install {0}'".format(e.req))
     if not upgradelist:
         pass
@@ -133,37 +79,6 @@ def dep_min_version():
             .format(pippackages))
 
 
-def update_timer():
-    # Checks for updates every X days on startup
-    try:
-        from castervoice.lib import settings
-        onlinemode = settings.SETTINGS["online"]["online_mode"]
-        lastupdate = settings.SETTINGS["online"]["last_update_date"] 
-        updateinterval = settings.SETTINGS["online"]["update_interval"]
-        if lastupdate == 'None':
-            lastupdate = str(date.today())
-            settings.SETTINGS["online"]["last_update_date"] = lastupdate
-        if onlinemode == True:
-            today = date.today()
-            lastdate = datetime.strptime(lastupdate, "%Y-%m-%d").date()
-            diff = today - lastdate 
-            if diff.days >= updateinterval: # int Days
-                if internet_check() == True:
-                    settings.SETTINGS["online"]["last_update_date"] = str(date.today())
-                    print "Searching for updates..."
-                    return True
-                else:
-                    print("\nCaster: Network off-line check network connection\n")
-                    return False
-            else:
-                return False
-        else:
-            print("\nCaster: Off-line mode is enabled\n")
-            return False
-    except ImportError:
-        return False
-
-
 class DependencyMan:
     # Initializes functions
     def initialize(self):
@@ -171,10 +86,6 @@ class DependencyMan:
         if install is "classic":
             dep_min_version()
             dep_missing()
-        if update_timer() == True:
-            dependency_check(command="dragonfly2")
-            if install is "pip":
-                dependency_check(command="castervoice")
 
     NATLINK = True
     PYWIN32 = True

--- a/castervoice/lib/ctrl/updatecheck.py
+++ b/castervoice/lib/ctrl/updatecheck.py
@@ -1,0 +1,99 @@
+import os, socket, subprocess
+from datetime import datetime, date
+
+from castervoice.lib import settings
+from castervoice.lib.ctrl.dependencies import find_pip, install_type
+
+
+update = None
+
+
+def internet_check(host="1.1.1.1", port=53, timeout=3):
+    """
+    Checks for network connection via DNS resolution.
+    :param host: CloudFire DNS
+    :param port: 53/tcp
+    :param timeout: An integer
+    :return: True or False
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.settimeout(timeout)
+        s.connect((host, port))
+        return True
+    except socket.error as e:
+        if e.errno == 11001:
+            print("Caster: Internet check failed to resolve CloudFire DNS")
+        if e.errno == 10051:  # Unreachable Network
+            pass
+        if e.errno not in (10051, 11001):  # Unknown Error
+            print(e.errno)
+        return False
+
+
+def update_check(command=None):
+    # Check for updates pip packages castervoice/dragonfly2
+    com = ["python", "-m", find_pip(), "search", command]
+    startupinfo = None
+    global update
+    try:
+        if os.name == 'nt':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        p = subprocess.Popen(com,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             stdin=subprocess.PIPE,
+                             startupinfo=startupinfo)
+        out = p.communicate('')
+        for line in out:
+            if "INSTALLED" and "latest" in line:
+                print("Caster: {0} is up-to-date".format(command.strip('2')))
+                update = False
+                break
+            else:
+                print("Caster: Say 'Update {0}' to update.".format(command.strip('2')))
+                update = True
+                break
+    except Exception as e:
+        print("Exception from starting subprocess {0}: " "{1}".format(com, e))
+
+
+def update_timer():
+    # Checks for updates every X days on startup
+    try:
+        onlinemode = settings.SETTINGS["online"]["online_mode"]
+        lastupdate = settings.SETTINGS["online"]["last_update_date"]
+        updateinterval = settings.SETTINGS["online"]["update_interval"]
+        if lastupdate == 'None':
+            lastupdate = str(date.today())
+            settings.SETTINGS["online"]["last_update_date"] = lastupdate
+        if onlinemode:
+            today = date.today()
+            lastdate = datetime.strptime(lastupdate, "%Y-%m-%d").date()
+            diff = today - lastdate
+            if diff.days >= updateinterval:  # int Days
+                if internet_check():
+                    settings.SETTINGS["online"]["last_update_date"] = str(date.today())
+                    print "Searching for updates..."
+                    return True
+                else:
+                    print("\nCaster: Network off-line check network connection\n")
+                    return False
+            else:
+                return False
+        else:
+            print("\nCaster: Off-line mode is enabled\n")
+            return False
+    except ImportError:
+        return False
+
+
+class UpdateChecker:
+    # Initializes functions
+    def initialize(self):
+        install = install_type()
+        if update_timer():
+            update_check(command="dragonfly2")
+            if install is "pip":
+                update_check(command="castervoice")

--- a/castervoice/lib/ctrl/updatecheck.py
+++ b/castervoice/lib/ctrl/updatecheck.py
@@ -32,8 +32,10 @@ def internet_check(host="1.1.1.1", port=53, timeout=3):
 
 
 def update_check(command=None):
+    
     # Check for updates pip packages castervoice/dragonfly2
-    com = ["python", "-m", find_pip(), "search", command]
+    # ToDo: Investigate why adding to com `"python", "-m"` causes erroneous update messages
+    com = [find_pip(), "search", command]
     startupinfo = None
     global update
     try:

--- a/castervoice/lib/ctrl/updatecheck.py
+++ b/castervoice/lib/ctrl/updatecheck.py
@@ -61,35 +61,32 @@ def update_check(command=None):
 
 def update_timer():
     # Checks for updates every X days on startup
-    try:
-        onlinemode = settings.SETTINGS["online"]["online_mode"]
-        lastupdate = settings.SETTINGS["online"]["last_update_date"]
-        updateinterval = settings.SETTINGS["online"]["update_interval"]
-        if lastupdate == 'None':
-            lastupdate = str(date.today())
-            settings.SETTINGS["online"]["last_update_date"] = lastupdate
-        if onlinemode:
-            today = date.today()
-            lastdate = datetime.strptime(lastupdate, "%Y-%m-%d").date()
-            diff = today - lastdate
-            if diff.days >= updateinterval:  # int Days
-                if internet_check():
-                    settings.SETTINGS["online"]["last_update_date"] = str(date.today())
-                    printer.out("Searching for updates...")
-                    return True
-                else:
-                    printer.out("\nCaster: Network off-line check network connection\n")
-                    return False
+    onlinemode = settings.SETTINGS["online"]["online_mode"]
+    lastupdate = settings.SETTINGS["online"]["last_update_date"]
+    updateinterval = settings.SETTINGS["online"]["update_interval"]
+    if lastupdate == 'None':
+        lastupdate = str(date.today())
+        settings.SETTINGS["online"]["last_update_date"] = lastupdate
+    if onlinemode:
+        today = date.today()
+        lastdate = datetime.strptime(lastupdate, "%Y-%m-%d").date()
+        diff = today - lastdate
+        if diff.days >= updateinterval:  # int Days
+            if internet_check():
+                settings.SETTINGS["online"]["last_update_date"] = str(date.today())
+                printer.out("Searching for updates...")
+                return True
             else:
+                printer.out("\nCaster: Network off-line check network connection\n")
                 return False
         else:
-            printer.out("\nCaster: Off-line mode is enabled\n")
             return False
-    except ImportError:
+    else:
+        printer.out("\nCaster: Off-line mode is enabled\n")
         return False
 
 
-class UpdateChecker:
+class UpdateChecker(object):
     # Initializes functions
     def initialize(self):
         install = install_type()

--- a/castervoice/lib/ctrl/updatecheck.py
+++ b/castervoice/lib/ctrl/updatecheck.py
@@ -3,7 +3,7 @@ from datetime import datetime, date
 
 from castervoice.lib import settings
 from castervoice.lib.ctrl.dependencies import find_pip, install_type
-
+from castervoice.lib import printer
 
 update = None
 
@@ -23,11 +23,11 @@ def internet_check(host="1.1.1.1", port=53, timeout=3):
         return True
     except socket.error as e:
         if e.errno == 11001:
-            print("Caster: Internet check failed to resolve CloudFire DNS")
+            printer.out("Caster: Internet check failed to resolve CloudFire DNS")
         if e.errno == 10051:  # Unreachable Network
             pass
         if e.errno not in (10051, 11001):  # Unknown Error
-            print(e.errno)
+            printer.out(e.errno)
         return False
 
 
@@ -48,15 +48,15 @@ def update_check(command=None):
         out = p.communicate('')
         for line in out:
             if "INSTALLED" and "latest" in line:
-                print("Caster: {0} is up-to-date".format(command.strip('2')))
+                printer.out("Caster: {0} is up-to-date".format(command.strip('2')))
                 update = False
                 break
             else:
-                print("Caster: Say 'Update {0}' to update.".format(command.strip('2')))
+                printer.out("Caster: Say 'Update {0}' to update.".format(command.strip('2')))
                 update = True
                 break
     except Exception as e:
-        print("Exception from starting subprocess {0}: " "{1}".format(com, e))
+        printer.out("Exception from starting subprocess {0}: " "{1}".format(com, e))
 
 
 def update_timer():
@@ -75,15 +75,15 @@ def update_timer():
             if diff.days >= updateinterval:  # int Days
                 if internet_check():
                     settings.SETTINGS["online"]["last_update_date"] = str(date.today())
-                    print "Searching for updates..."
+                    printer.out("Searching for updates...")
                     return True
                 else:
-                    print("\nCaster: Network off-line check network connection\n")
+                    printer.out("\nCaster: Network off-line check network connection\n")
                     return False
             else:
                 return False
         else:
-            print("\nCaster: Off-line mode is enabled\n")
+            printer.out("\nCaster: Off-line mode is enabled\n")
             return False
     except ImportError:
         return False

--- a/castervoice/rules/core/utility_rules/caster_rule.py
+++ b/castervoice/rules/core/utility_rules/caster_rule.py
@@ -1,7 +1,8 @@
 from dragonfly import MappingRule, Function, RunCommand, Playback
 
 from castervoice.lib import control
-from castervoice.lib.ctrl.dependencies import update, find_pip
+from castervoice.lib.ctrl.dependencies import find_pip
+from castervoice.lib.ctrl.updatecheck import update
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 
@@ -24,8 +25,9 @@ class _DependencyUpdate(RunCommand):
 class CasterRule(MappingRule):
     mapping = {
         # update management
-        "update caster":
-            R(_DependencyUpdate([_PIP, "install", "--upgrade", "castervoice"])),
+        
+        # "update caster": ToDo: Implement pip caster install
+        #     R(_DependencyUpdate([_PIP, "install", "--upgrade", "castervoice"])),
         "update dragonfly":
             R(_DependencyUpdate([_PIP, "install", "--upgrade", "dragonfly2"])),
 

--- a/castervoice/rules/core/utility_rules/caster_rule.py
+++ b/castervoice/rules/core/utility_rules/caster_rule.py
@@ -25,9 +25,8 @@ class _DependencyUpdate(RunCommand):
 class CasterRule(MappingRule):
     mapping = {
         # update management
-        
-        # "update caster": ToDo: Implement pip caster install
-        #     R(_DependencyUpdate([_PIP, "install", "--upgrade", "castervoice"])),
+        "update caster":
+            R(_DependencyUpdate([_PIP, "install", "--upgrade", "castervoice"])),
         "update dragonfly":
             R(_DependencyUpdate([_PIP, "install", "--upgrade", "dragonfly2"])),
 


### PR DESCRIPTION
# Description

Re-factored `update_check` out of `DependencyMan`.

## Motivation and Context

The motivation comes from two issues.
1. `update_check` relies on checking settings.toml for update. Previously this was checked before settings was initialized in _caster.py quantitatively initializing settings twice. Now settings is initialized in `_caster.py` before `update_check` is called.

2. `DependencyMan` dependencies are only standard library and runs before settings are initialized. This means if there's any missing/version specific dependencies the user will be notified appropriately instead of a trace back immediately.

## How Has This Been Tested

- Ongoing `"python", "-m"` causes erroneous update notification in `["python", "-m", find_pip(), "search", command]` further testing is required.

The tricky bit `python -m  pip search dragonfly2` and `pip search dragonfly2` output is the same from command prompt. 

The update check checks output for the following `if "INSTALLED" and "latest" in line`. 
```
PS C:\Users\Main> pip search dragonfly2
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
dragonfly2 (0.20.0)  - Speech recognition extension library
  INSTALLED: 0.20.0 (latest)
```
```
PS C:\Users\Main> python -m pip search dragonfly2
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
dragonfly2 (0.20.0)  - Speech recognition extension library
  INSTALLED: 0.20.0 (latest)
```

- Regenerating settings and testing update mechanisms.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
