### PR TITLE
`again do`command set index 2 for last utterance

### DIFF
--- a/castervoice/rules/ccr/recording_rules/again.py
+++ b/castervoice/rules/ccr/recording_rules/again.py
@@ -29,7 +29,7 @@ class Again(MappingRule):
         if len(_history) == 0:
             return
 
-        last_utterance_index = 1
+        last_utterance_index = 2
         if settings.WSR:  # ContextStack adds the word to history before executing it
             if len(_history) == 1: return
             last_utterance_index = 2


### PR DESCRIPTION
## Description

`again do` always returned `if utterance[0] == "again": return` because the last entry going to be the `again` `do` command. Changing `last_utterance_index = 1` to `last_utterance_index = 2` ensures that it does not return so the function completes.

## Related Issue

The Again grammar does not function as expected. #729

## How Has This Been Tested

Tested with and without an integer.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
