### PR TITLE
Only trigger alias GUI without a defined alias spec

### DIFF
--- a/castervoice/rules/ccr/recording_rules/alias/base_alias.py
+++ b/castervoice/rules/ccr/recording_rules/alias/base_alias.py
@@ -55,17 +55,17 @@ class BaseAliasRule(BaseSelfModifyingRule):
         text = BaseAliasRule._read_highlighted(10)
         spec = str(spec)
         if text is not None:
-            # if spec:
-            #     self._refresh(spec, str(text))
-            # else:
-            h_launch.launch(settings.QTYPE_INSTRUCTIONS, data="Enter_spec_for_command|")
-            on_complete = AsynchronousAction.hmc_complete(
-                lambda data: self._refresh(data[0].replace("\n", ""), text))
-            AsynchronousAction(
-                [L(S(["cancel"], on_complete))],
-                time_in_seconds=0.5,
-                repetitions=300,
-                blocking=False).execute()
+            if spec:
+                self._refresh(spec, str(text))
+            else:
+                h_launch.launch(settings.QTYPE_INSTRUCTIONS, data="Enter_spec_for_command|")
+                on_complete = AsynchronousAction.hmc_complete(
+                    lambda data: self._refresh(data[0].replace("\n", ""), text))
+                AsynchronousAction(
+                    [L(S(["cancel"], on_complete))],
+                    time_in_seconds=0.5,
+                    repetitions=300,
+                    blocking=False).execute()
 
     def _delete_all(self):
         self._config.replace({})


### PR DESCRIPTION
## Description

When the alias command is triggered by voice without a spec GUI appears for the user to input one. Previously this appeared whether or not the user had defined a spec. The GUI appears only in the correct conditions. 



## Related Issue
none

## Motivation and Context

See description

## How Has This Been Tested

This is been tested both with the chain alias is and alias commands. Selecting text and saying the `alias` with `any word` and the GUI does not appear. Say `alias` without a word and GUI appears appropriately.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
