### PR TITLE
Separate core grammars into unit test

### DIFF
--- a/tests/rules/ccr/test_rule_modules.py
+++ b/tests/rules/ccr/test_rule_modules.py
@@ -1,15 +1,8 @@
 from tests.test_util.modules_testing import ModulesTestCase
 
-
 class CCRModulesTestCase(ModulesTestCase):
     def _rule_modules(self):
         from castervoice.rules.ccr.bash_rules import bash
-        from castervoice.rules.core.text_manipulation_rules import text_manipulation
-        from castervoice.rules.core.numbers_rules import numeric
-        from castervoice.rules.core.navigation_rules import nav
-        from castervoice.rules.core.navigation_rules import nav2
-        from castervoice.rules.core.alphabet_rules import alphabet
-        from castervoice.rules.core.punctuation_rules import punctuation
         from castervoice.rules.ccr.cpp_rules import cpp
         from castervoice.rules.ccr.csharp_rules import csharp
         from castervoice.rules.ccr.dart_rules import dart
@@ -39,8 +32,7 @@ class CCRModulesTestCase(ModulesTestCase):
         from castervoice.rules.ccr.vhdl_rules import vhdl2
         from castervoice.rules.ccr.vhdl_rules import vhdl
         from castervoice.rules.ccr.voice_dev_commands_rules import voice_dev_commands
-        return [bash, alphabet, nav, nav2, numeric, punctuation,
-                text_manipulation, cpp, csharp, dart, go, haxe,
+        return [bash, cpp, csharp, dart, go, haxe,
                 html_rule, java, java2, javascript, latex,
                 markdown, matlab, matlab2, prolog, prolog2,
                 python, python2, r, chain_alias, simple_alias,

--- a/tests/rules/core/test_rule_modules.py
+++ b/tests/rules/core/test_rule_modules.py
@@ -1,0 +1,19 @@
+from tests.test_util.modules_testing import ModulesTestCase
+
+
+class CoreModulesTestCase(ModulesTestCase):
+    def _rule_modules(self):
+        from castervoice.rules.core.text_manipulation_rules import text_manipulation
+        from castervoice.rules.core.numbers_rules import numeric
+        from castervoice.rules.core.navigation_rules import nav
+        from castervoice.rules.core.navigation_rules import nav2
+        from castervoice.rules.core.navigation_rules import window_mgmt_rule
+        from castervoice.rules.core.alphabet_rules import alphabet
+        from castervoice.rules.core.punctuation_rules import punctuation
+        from castervoice.rules.core.utility_rules import caster_rule
+        from castervoice.rules.core.utility_rules import hardware_rule
+        from castervoice.rules.core.utility_rules import mouse_alts_rules
+
+        return [alphabet, nav, nav2, window_mgmt_rule, numeric, punctuation,
+                text_manipulation, caster_rule,
+                hardware_rule, mouse_alts_rules]


### PR DESCRIPTION


## Description
Separate core grammars into its own unit test that reflects caster file structure.
added hardware_rule, mouse_alts_rules, caster_rule, window_mgmt_rule

## Related Issue

None

## Motivation and Context

Best practice is to have your unit tests mimic the file structure of the project.

## How Has This Been Tested

Run unit tests through pycharm 
95 to 99 unit tests and passing

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

 if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
