### PR TITLE
Pass-through text formatting commands

### DIFF
--- a/castervoice/lib/textformat.py
+++ b/castervoice/lib/textformat.py
@@ -14,6 +14,9 @@ class TextFormat():
     3 Gerrish - camelCase
     4 sing - Sentencecase
     5 laws (default) - alllower
+    6 say - whatever speech engine provides
+    7 cop - Whatever speech engine provides, initial letter capitalized
+    8 slip - whatever speech engine provides, initial letter lowercase
     Commands for word spacing:
     0 (default except Gerrish) - words with spaces
     1 gum (default for Gerrish)  - wordstogether
@@ -21,6 +24,7 @@ class TextFormat():
     3 snake - words_with_underscores
     4 pebble - words.with.fullstops
     5 incline - words/with/slashes
+    6 descent - words\with\backslashes
     '''
 
     @classmethod
@@ -36,6 +40,12 @@ class TextFormat():
                 t = t.capitalize()
             elif capitalization == 5:
                 t = t.lower()
+            elif capitalization == 6:
+                pass
+            elif capitalization == 7:
+                t = t[0].upper() + t[1:]
+            elif capitalization == 8:
+                t = t[0].lower() + t[1:]
         if spacing != 0:
             if spacing == 1:
                 t = "".join(t.split(" "))
@@ -53,7 +63,7 @@ class TextFormat():
 
     @classmethod
     def get_text_format_description(cls, capitalization, spacing):
-        caps = {0: "<none>", 1: "yell", 2: "tie", 3: "gerrish", 4: "sing", 5: "laws"}
+        caps = {0: "<none>", 1: "yell", 2: "tie", 3: "gerrish", 4: "sing", 5: "laws", 6: "say", 7: "cop", 8: "slip"}
         spaces = {
             0: "<none>",
             1: "gum",

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -287,7 +287,10 @@ class Navigation(MergeRule):
             "tie": 2,
             "gerrish": 3,
             "sing": 4,
-            "laws": 5
+            "laws": 5,
+            "say": 6,
+            "cop": 7,
+            "slip": 8,
         }),
         Choice(
             "spacing", {
@@ -298,7 +301,7 @@ class Navigation(MergeRule):
                 "pebble": 4,
                 "incline": 5,
                 "dissent": 6,
-                "descent": 6
+                "descent": 6,
             }),
         Choice("semi", tell_commands_dict),
         Choice("word_limit", {

--- a/tests/lib/test_textFormat.py
+++ b/tests/lib/test_textFormat.py
@@ -20,6 +20,12 @@ class TestTextFormat(unittest.TestCase):
         self.assertEqual(test_string, 'This.is.a.test')
         test_string = TextFormat.formatted_text(5, 5, 'this is a test')
         self.assertEqual(test_string, 'this/is/a/test')
+        test_string = TextFormat.formatted_text(6, 6, 'tHiS Is a TeSt')
+        self.assertEqual(test_string, 'tHiS\\Is\\a\\TeSt')
+        test_string = TextFormat.formatted_text(7, 6, 'tHiS Is a TeSt')
+        self.assertEqual(test_string, 'THiS\\Is\\a\\TeSt')
+        test_string = TextFormat.formatted_text(8, 6, 'THiS Is a TeSt')
+        self.assertEqual(test_string, 'tHiS\\Is\\a\\TeSt')
 
     def test_set_text_format(self):
         self.text_format.set_text_format(1, 2)


### PR DESCRIPTION
 When I am writing natural language,
for example in comments and READMEs,
I often wish the dictation would allow Dragon to
choose the capitalization method for me.
Sometimes I want to choose the initial letter, however.

As an example consider the phrase,
"My name is Dusty and I like to dictate"

If I dictate this without a caster command,
it comes up the way I want it to,
but I often use either 'Sing' or 'laws'
because I want to control the capitalization of the 1st letter,
or because I want to insert it with other commands in CCR mode.

When I do that to my example sentence,
it lowercases my name and the 1st person 'I.'
The 3 text formatting commands I've added
operate on only the 1st character, but leave the remaining
words is capitalized by Dragon.