### PR TITLE
Simplify grammar manager error messages.

### DIFF
--- a/castervoice/lib/ctrl/mgr/grammar_manager.py
+++ b/castervoice/lib/ctrl/mgr/grammar_manager.py
@@ -287,14 +287,17 @@ class GrammarManager(object):
         :param file_path_changed: str
         :return:
         """
-        module_name = GrammarManager._get_module_name_from_file_path(file_path_changed)
-        rule_class, details = self._content_loader.idem_import_module(module_name, ContentType.GET_RULE)
-        # re-register:
-        self.register_rule(rule_class, details)
+        try:
+            module_name = GrammarManager._get_module_name_from_file_path(file_path_changed)
+            rule_class, details = self._content_loader.idem_import_module(module_name, ContentType.GET_RULE)
+            # re-register:
+            self.register_rule(rule_class, details)
 
-        class_name = rule_class.__name__
-        if class_name in self._config.get_enabled_rcns_ordered():
-            self._delegate_enable_rule(class_name, True)
+            class_name = rule_class.__name__
+            if class_name in self._config.get_enabled_rcns_ordered():
+                self._delegate_enable_rule(class_name, True)
+        except Exception as e:
+            print('Grammar Manager: {} - See error message above'.format(e)) 
 
     def _get_invalidation(self, rule_class, details):
         """


### PR DESCRIPTION
Description

Simplifies error messages from the grammar manager specifically the function `def receive` is part of reloading grammars.

Previous error message
```
An error occurred while importing '<module 'Firefox' from 'C:\Users\Admin\AppData\Local\caster\rules\Firefox.py'>': Traceback (most recent call last):
  File "C:\Users\Admin\Documents\Caster\castervoice\lib\ctrl\mgr\loading\load\content_loader.py", line 133, in _reimport_module
    return reload_fn(module)
  File "C:\Users\Admin\AppData\Local\caster\rules\Firefox.py", line 112, in <module>
    hello
NameError: name 'hello' is not defined

2020-02-04 12:41:54,207 : ERROR : call
Exception during timer callback: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\dragonfly2-0.20.0-py2.7.egg\dragonfly\engines\base\timer.py", line 91, in call
    self.function()
  File "C:\Users\Admin\Documents\Caster\castervoice\lib\ctrl\mgr\loading\reload\timer_reload_observable.py", line 18, in <lambda>
    get_engine().create_timer(lambda: self._update(), self._time_in_seconds)
  File "C:\Users\Admin\Documents\Caster\castervoice\lib\ctrl\mgr\loading\reload\base_reload_observable.py", line 35, in _update
    self._notify_listeners(file_path)
  File "C:\Users\Admin\Documents\Caster\castervoice\lib\ctrl\mgr\loading\reload\base_reload_observable.py", line 49, in _notify_listeners
    listener.receive(path_changed)
  File "C:\Users\Admin\Documents\Caster\castervoice\lib\ctrl\mgr\grammar_manager.py", line 291, in receive
    rule_class, details = self._content_loader.idem_import_module(module_name, ContentType.GET_RULE)
TypeError: 'NoneType' object is not iterable
```

Simplified error message
```
An error occurred while importing '<module 'firefox' from 'D:\Backup\Library\Documents\Caster\castervoice\rules\apps\browser\firefox.py'>': Traceback (most recent call last):
  File "castervoice\lib\ctrl\mgr\loading\load\content_loader.py", line 133, in _reimport_module
    return reload_fn(module)
  File "D:\Backup\Library\Documents\Caster\castervoice\rules\apps\browser\firefox.py", line 12, in <module>
    hello
NameError: name 'hello' is not defined

Grammar Manager: 'NoneType' object is not iterable - See error message above
Reloaded D:/Backup/Library/Documents/Caster/castervoice/rules/apps/browser/firefox.py
```

## Related Issue

None

## Motivation and Context

Previously error messages were very verbose printing out to tracebacks. The first traceback (most likely containing the relevant error) then a grammar manager which would change depending on what was invalid in the grammar.

## How Has This Been Tested

Passes current unit tests and manual testing with invalidating grammars such as syntax errors and invalid imports.

## Types of changes

Quality of life.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
