### PR TITLE
Error handling for stale .pyc files

### DIFF
--- a/castervoice/lib/ctrl/mgr/rule_details.py
+++ b/castervoice/lib/ctrl/mgr/rule_details.py
@@ -1,4 +1,6 @@
+import os, traceback
 import inspect
+from castervoice.lib import printer
 
 
 class RuleDetails(object):
@@ -32,12 +34,19 @@ class RuleDetails(object):
 
     @staticmethod
     def _calculate_filepath_from_frame(stack, index):
-        frame = stack[index]
-        module = inspect.getmodule(frame[0])
-        filepath = module.__file__.replace("\\", "/")
-        if filepath.endswith("pyc"):
-            filepath = filepath[:-1]
-        return filepath
+        try:
+            frame = stack[index]
+            module = inspect.getmodule(frame[0])
+            filepath = module.__file__.replace("\\", "/")  
+            if filepath.endswith("pyc"):
+                filepath = filepath[:-1]
+            return filepath
+        except AttributeError as e:
+            if not os.path.isfile(frame[1]):
+                printer.out("\n {} \n File does not exist. A stale .pyc file is in the same dir."
+                "\n Delete the .pyc file that has the same name in the file path.\n".format(frame[1]))
+            else:
+                traceback.print_exc()
 
     def get_filepath(self):
         return self._filepath

--- a/castervoice/lib/ctrl/mgr/rule_details.py
+++ b/castervoice/lib/ctrl/mgr/rule_details.py
@@ -43,8 +43,10 @@ class RuleDetails(object):
             return filepath
         except AttributeError as e:
             if not os.path.isfile(frame[1]):
-                printer.out("\n {} \n File does not exist. A stale .pyc file is in the same dir."
-                "\n Delete the .pyc file that has the same name in the file path.\n".format(frame[1]))
+                pyc = frame[1] + "c"
+                if os.path.isfile(pyc):
+                    printer.out("\n {} \n Caster Detected a stale .pyc file. The stale file has been removed please restart Caster. \n".format(pyc))
+                    os.remove(pyc)
             else:
                 traceback.print_exc()
 


### PR DESCRIPTION
## Description

Adds the try except block to _calculate_filepath_from_frame and deletes the stale .pyc file. More details and related tissue.

Technically this pull request does not fix the issue of caster trying to load stale `.pyc` A more advanced approach would be to delete the erroneous .pyc and rerun the function.

**Update** Implemented to Deleting stale .pyc. rerunning the function is prohibitive because `inspect.stack` does not contain the correct reference to the correct existing Python grammar file. To my knowledge this can only be resolved by restarting Caster.

## Related Issue

Stale `.pyc` files can cause Caster to crash. #744

## Motivation and Context

The message is printed in the exception rather than raised because Caster can continue running. The related rule related to the stale .pyc won't load until caster is reloaded.

## How Has This Been Tested

Reference reproduce section in related issue.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
