### PR TITLE
Re-implemented on error show window using hooks

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -6,9 +6,6 @@ Created on Jun 29, 2014
 import datetime
 import logging
 
-logging.basicConfig(format = "%(asctime)s : %(levelname)s : %(funcName)s\n%(msg)s")   
-
-
 from castervoice.lib.ctrl.dependencies import DependencyMan  # requires nothing
 DependencyMan().initialize()
 
@@ -19,38 +16,8 @@ from castervoice.lib.ctrl.updatecheck import UpdateChecker # requires settings/d
 UpdateChecker().initialize()
 
 from dragonfly import get_engine
-from dragonfly.windows.window import Window
-
 
 _NEXUS = None
-
-class LoggingHandler(logging.Handler):
-    def emit(self, record):
-        # Brings status window to the forefront upon error
-        if settings.SETTINGS["miscellaneous"]["status_window_foreground_on_error"]:
-            title = None
-            if get_engine()._name == 'natlink':
-                import natlinkstatus  # pylint: disable=import-error
-                status = natlinkstatus.NatlinkStatus()
-                if status.NatlinkIsEnabled() == 1:
-                    title = "Messages from Python Macros V"
-                else:
-                    title = "Windows PowerShell"
-            if get_engine()._name != 'natlink':
-                title = "Windows PowerShell"
-            windows = Window.get_matching_windows(title=title)
-            if windows:
-                windows[0].set_foreground()
-
-if settings.SETTINGS["miscellaneous"]["status_window_foreground_on_error"]:
-    # setLevel 40 = Error
-    logger1 = logging.getLogger('action')
-    logger1.setLevel(40)
-    logger1.addHandler(LoggingHandler())
-
-    logger2 = logging.getLogger('engine')
-    logger2.setLevel(40)
-    logger2.addHandler(LoggingHandler())
 
 settings.WSR = __name__ == "__main__"
 

--- a/castervoice/lib/ctrl/mgr/grammar_manager.py
+++ b/castervoice/lib/ctrl/mgr/grammar_manager.py
@@ -10,6 +10,7 @@ from castervoice.lib.ctrl.mgr.managed_rule import ManagedRule
 from castervoice.lib.ctrl.mgr.rule_formatter import _set_rdescripts
 from castervoice.lib.ctrl.mgr.rules_enabled_diff import RulesEnabledDiff
 from castervoice.lib.merge.ccrmerging2.hooks.events.activation_event import RuleActivationEvent
+from castervoice.lib.merge.ccrmerging2.hooks.events.on_error_event import OnErrorEvent
 from castervoice.lib.merge.ccrmerging2.sorting.config_ruleset_sorter import ConfigBasedRuleSetSorter
 from castervoice.lib.util.ordered_set import OrderedSet
 
@@ -296,8 +297,9 @@ class GrammarManager(object):
             class_name = rule_class.__name__
             if class_name in self._config.get_enabled_rcns_ordered():
                 self._delegate_enable_rule(class_name, True)
-        except Exception as e:
-            print('Grammar Manager: {} - See error message above'.format(e)) 
+        except Exception as error:
+            print('Grammar Manager: {} - See error message above'.format(error)) 
+            self._hooks_runner.execute(OnErrorEvent())
 
     def _get_invalidation(self, rule_class, details):
         """

--- a/castervoice/lib/ctrl/mgr/grammar_manager.py
+++ b/castervoice/lib/ctrl/mgr/grammar_manager.py
@@ -298,7 +298,7 @@ class GrammarManager(object):
             if class_name in self._config.get_enabled_rcns_ordered():
                 self._delegate_enable_rule(class_name, True)
         except Exception as error:
-            print('Grammar Manager: {} - See error message above'.format(error)) 
+            printer.out('Grammar Manager: {} - See error message above'.format(error)) 
             self._hooks_runner.execute(OnErrorEvent())
 
     def _get_invalidation(self, rule_class, details):

--- a/castervoice/lib/merge/ccrmerging2/hooks/events/event_types.py
+++ b/castervoice/lib/merge/ccrmerging2/hooks/events/event_types.py
@@ -1,3 +1,4 @@
 class EventType(object):
     ACTIVATION = "activation"
     NODE_CHANGE = "node change"
+    ON_ERROR = "on error"

--- a/castervoice/lib/merge/ccrmerging2/hooks/events/on_error_event.py
+++ b/castervoice/lib/merge/ccrmerging2/hooks/events/on_error_event.py
@@ -1,0 +1,8 @@
+from castervoice.lib.merge.ccrmerging2.hooks.events.base_event import BaseHookEvent
+from castervoice.lib.merge.ccrmerging2.hooks.events.event_types import EventType
+
+
+class OnErrorEvent(BaseHookEvent):
+    def __init__(self):
+        super(OnErrorEvent, self).__init__(EventType.ON_ERROR)
+        

--- a/castervoice/lib/merge/ccrmerging2/hooks/standard_hooks/show_window_on_error_hook.py
+++ b/castervoice/lib/merge/ccrmerging2/hooks/standard_hooks/show_window_on_error_hook.py
@@ -1,0 +1,37 @@
+from castervoice.lib import settings, textformat
+from castervoice.lib.merge.ccrmerging2.hooks.base_hook import BaseHook
+from castervoice.lib.merge.ccrmerging2.hooks.events.event_types import EventType
+from castervoice.lib import printer
+
+from dragonfly import get_engine
+from dragonfly.windows.window import Window
+
+def show_window():
+    title = None
+    if get_engine()._name == 'natlink':
+        import natlinkstatus  # pylint: disable=import-error
+        status = natlinkstatus.NatlinkStatus()
+        if status.NatlinkIsEnabled() == 1:
+            title = "Messages from Python Macros V"
+        else:
+            title = "Windows PowerShell"
+    if get_engine()._name != 'natlink':
+        title = "Windows PowerShell"
+    windows = Window.get_matching_windows(title=title)
+    if windows:
+        windows[0].set_foreground()
+
+
+class ShowStatusWindowOnErrorHook(BaseHook):
+    def __init__(self):
+        super(ShowStatusWindowOnErrorHook, self).__init__(EventType.ON_ERROR)
+
+    def get_pronunciation(self):
+        return "show status error"
+
+    def run(self, event_data):
+        printer.out("run")
+        show_window()
+
+def get_hook():
+    return ShowStatusWindowOnErrorHook

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -379,7 +379,6 @@ def _get_defaults():
             "use_aenea": False,
             "hmc": True,
             "ccr_on": True,
-            "status_window_foreground_on_error": False,
             "dragonfly_pause_default":  0.003, # dragonfly _pause_default 0.02 is too slow! Caster default 0.003
         },
         # Grammar reloading section


### PR DESCRIPTION
## Description

Re-implemented on error show window using hooks.

## Related Issue

None

## Motivation and Context


The previous implementation was not elegant using logging. A `OnError` event has been created with `ShowStatusWindowOnErrorHook`. Currently the event does not pass data to the hook. The Hook system has two distinct advantages over the previous logging implementation. 

1. ShowStatusWindowOnErrorHook can placed in the CodeBase selectively so that certain errors because that's desired behavior.
2. Does not require an error type to be triggered.
3. The feature can be enabled and disabled while Caster is running.

Show status window on error only occurs when there is an error reloading the grammar. Other hooks could be placed in the CodeBase as needed.

## How Has This Been Tested

Tested reloading a grammar with an syntax error.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
