### PR TITLE
Fix settings window crash on complete command on Windows

### DIFF
--- a/castervoice/asynch/hmc/homunculus.py
+++ b/castervoice/asynch/hmc/homunculus.py
@@ -67,7 +67,8 @@ class Homunculus(tk.Tk):
         self.server_quit = 0
         comm = Communicator()
         self.server = SimpleXMLRPCServer(
-            (Communicator.LOCALHOST, comm.com_registry["hmc"]), allow_none=True)
+            (Communicator.LOCALHOST, comm.com_registry["hmc"]),
+            logRequests=False, allow_none=True)
         self.server.register_function(self.xmlrpc_do_action, "do_action")
         self.server.register_function(self.xmlrpc_complete, "complete")
         self.server.register_function(self.xmlrpc_get_message, "get_message")

--- a/castervoice/asynch/mouse/grids.py
+++ b/castervoice/asynch/mouse/grids.py
@@ -106,7 +106,8 @@ class TkTransparent(tk.Tk):
         self.server_quit = 0
         comm = Communicator()
         self.server = SimpleXMLRPCServer(
-            (Communicator.LOCALHOST, comm.com_registry["grids"]), allow_none=True)
+            (Communicator.LOCALHOST, comm.com_registry["grids"]),
+            logRequests=False, allow_none=True)
         self.server.register_function(self.xmlrpc_kill, "kill")
 
     def pre_redraw(self):

--- a/castervoice/asynch/sikuli/server/xmlrpc_server.sikuli/xmlrpc_server.py
+++ b/castervoice/asynch/sikuli/server/xmlrpc_server.sikuli/xmlrpc_server.py
@@ -8,7 +8,7 @@ import sys
 from inspect import getmembers, isfunction
 
 modules = []
-server = SimpleXMLRPCServer(("127.0.0.1", 8000), allow_none=True)
+server = SimpleXMLRPCServer(("127.0.0.1", 8000), logRequests=False, allow_none=True)
 quit = 0
 
 SCRIPTS_PATH = sys.argv[1]


### PR DESCRIPTION
# Title

Fix issue #761 

## Description

The crash happens because logging enabled by default for the RPC
server interferes with the client-server communication when the server
runs on pythonw.

In addition, make sure that methods on GUI widgets are invoked on the
main thread.  When RPC server receives a command that manipulates GUI
widgets, it issues an event which handled on the main thread, and then
widget methods are called by the event handler on the main thread.

## Related Issue

#761

## Motivation and Context

Fixes a crash

## How Has This Been Tested

Tested on Windows and macOS by running the GUI and interacting with it from Caster via dragonfly test engine

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
