### PR TITLE
Add Dragonfly FuncContext support

### DIFF
--- a/castervoice/lib/ctrl/mgr/rule_details.py
+++ b/castervoice/lib/ctrl/mgr/rule_details.py
@@ -8,19 +8,21 @@ class RuleDetails(object):
     A per-rule instantiation configuration.
     """
 
-    def __init__(self, name=None, executable=None, title=None, grammar_name=None,
+    def __init__(self, name=None, function_context=None, executable=None, title=None, grammar_name=None,
                  ccrtype=None, transformer_exclusion=False,
                  watch_exclusion=False):
         """
         :param name: Dragonfly rule name
-        :param executable: Dragonfly AppContext executable
-        :param title: Dragonfly AppContext title
+        :param function_context: Dragonfly FunctionContext bool variable
+        :param executable: Dragonfly Context executable
+        :param title: Dragonfly Context title
         :param grammar_name: Dragonfly grammar name
         :param ccrtype: global, app, selfmod, or none
         :param transformer_exclusion: exclude from transformations
         :param watch_exclusion: should not be watched for changes ("system" rules)
         """
         self.name = name
+        self.function_context = function_context
         self.executable = executable
         self.title = title
         self.grammar_name = grammar_name

--- a/castervoice/lib/ctrl/mgr/rule_maker/mapping_rule_maker.py
+++ b/castervoice/lib/ctrl/mgr/rule_maker/mapping_rule_maker.py
@@ -1,4 +1,4 @@
-from dragonfly import Grammar
+from dragonfly import Grammar, FuncContext
 from castervoice.lib.context import AppContext
 from castervoice.lib.ctrl.mgr.rule_maker.base_rule_maker import BaseRuleMaker
 
@@ -24,8 +24,11 @@ class MappingRuleMaker(BaseRuleMaker):
         self._smr_configurer.configure(rule_instance)
 
         context = None
-        if details.executable is not None or details.title is not None:
-            context = AppContext(executable=details.executable, title=details.title)
+        if details.function_context is not None:
+            context = FuncContext(function=details.function_context, executable=details.executable, title=details.title)
+        else:
+            if details.executable is not None or details.title is not None:
+                context = AppContext(executable=details.executable, title=details.title)
         self._name_uniquefier += 1
         counter = "g" + str(self._name_uniquefier)
         grammar_name = counter if details.grammar_name is None else details.grammar_name + counter

--- a/castervoice/lib/ctrl/mgr/validation/details/function_context_validator.py
+++ b/castervoice/lib/ctrl/mgr/validation/details/function_context_validator.py
@@ -1,0 +1,14 @@
+from castervoice.lib.ctrl.mgr.validation.details.base_validator import BaseDetailsValidator
+
+
+class FunctionContextDetailsValidator(BaseDetailsValidator):
+
+    '''
+    Validates any Function Context Details
+    '''
+    def validate(self, details):
+        invalidations = []
+        if details.function_context is not bool:
+                invalidations.append("Function Context must return a bool value")
+
+        return None if len(invalidations) == 0 else ", ".join(invalidations)

--- a/castervoice/lib/ctrl/mgr/validation/details/function_context_validator.py
+++ b/castervoice/lib/ctrl/mgr/validation/details/function_context_validator.py
@@ -1,3 +1,4 @@
+from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.validation.details.base_validator import BaseDetailsValidator
 
 
@@ -9,6 +10,9 @@ class FunctionContextDetailsValidator(BaseDetailsValidator):
     def validate(self, details):
         invalidations = []
         if details.function_context is not bool:
-                invalidations.append("Function Context must return a bool value")
+            invalidations.append("Function Context must return a bool value")
+        if details.declared_ccrtype == CCRType.GLOBAL:
+            invalidations.append("Function Context cannot be used with `CCRType.GLOBAL`")
+
 
         return None if len(invalidations) == 0 else ", ".join(invalidations)

--- a/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
+++ b/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
@@ -1,5 +1,6 @@
 from dragonfly.grammar.elements import RuleRef, Alternative, Repetition
 from dragonfly.grammar.rule_compound import CompoundRule
+from dragonfly import FuncContext
 from castervoice.lib.const import CCRType
 from castervoice.lib.context import AppContext
 from castervoice.lib.ctrl.mgr.rules_enabled_diff import RulesEnabledDiff
@@ -149,7 +150,10 @@ class CCRMerger2(object):
         negation_context = None
         for cr in app_crs:
             details = rcns_to_details[cr.rule_class_name()]
-            context = AppContext(executable=details.executable, title=details.title)
+            if details.function_context is not None:
+                context = FuncContext(function=details.function_context, executable=details.executable, title=details.title)
+            else:
+                context = AppContext(executable=details.executable, title=details.title)
             contexts.append(context)
             if negation_context is None:
                 negation_context = ~context

--- a/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
+++ b/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
@@ -136,7 +136,7 @@ class CCRMerger2(object):
     @staticmethod
     def _create_contexts(app_crs, rcns_to_details):
         """
-        Returns a list of AppContexts, based on 'executable', one for each
+        Returns a list of contexts, AppContexts based on 'executable', FuncContext, one for each
         app rule, and if more than zero app rules, the negation context for the
         global ccr rule. (Global rule should be active when none of the other
         contexts are.) If there are zero app rules, [None] will be returned


### PR DESCRIPTION
## Description

This ad support for Dragonfly function context. Context class that evaluates a given function, whose return value is interpreted as a bool, determining whether the context is active.  

## Related Issue

https://github.com/dictation-toolbox/Caster/issues/747

## Motivation and Context

While AppContext does most of what we want FuncContext has significant use cases such as Enabling grammars by modes modes such as Vim and so forth.


## How Has This Been Tested

This has been tested with mapping rules and app CCR. I have not managed to get of working with Global CCR. Rule detail validator's check FuncContext's function for a bool value and Global CCR type.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. Will update the documentation in https://github.com/dictation-toolbox/Caster/pull/756
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
