### PR TITLE
[Trivial change] Fix broken sample.py command

### DIFF
--- a/docs/readthedocs/Rule_Construction/Dragonfly_Rules/Sample_File.md
+++ b/docs/readthedocs/Rule_Construction/Dragonfly_Rules/Sample_File.md
@@ -57,7 +57,7 @@ class MainRule(MappingRule):
      # Sometimes it's easier to have things as a list in a command as a choice that do different things.
      # The `<choice>` defined in `extras` allows you define that list. If you dictate `I choose custom grid` Then `CustomGrid` will be printed as text.
      # Items in the list are pairs. e.g `{"custom grid": "CustomGrid"}` The first item of a pair is the command "custom grid" and the second "CustomGrid" output text action.   
-    "i choose <choice>":              Text("<choice>"),
+    "i choose <choice>":              Text("%(choice)s"),
         
     }
 

--- a/sample.py
+++ b/sample.py
@@ -52,7 +52,7 @@ class MainRule(MappingRule):
      # Sometimes it's easier to have things as a list in a command as a choice that do different things.
      # That's what `<choice>` Is defined in `extras` allows you define that list. If you dictate `i choose custom grid` Then `CustomGrid` will be printed as text.
      # Items in the list are pairs. e.g `{"custom grid": "CustomGrid"}` The first item of a pair is the command "custom grid" and the second "CustomGrid" output text action.   
-    "i choose <choice>":              Text("<choice>"),
+    "i choose <choice>":              Text("%(choice)s"),
         
     }
 


### PR DESCRIPTION
# [Trivial change] Fix broken sample.py command
The output of `"i choose <choice>" : Text("<choice>")` was just `<choice>`