### PR TITLE
Standardising function keys

### DIFF
--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -210,7 +210,7 @@ class Navigation(MergeRule):
         "space": "space"
     }
     button_dictionary_10 = {
-        "F{}".format(i) : "f{}".format(i)
+        "(F{}".format(i) + " | function {})".format(i) : "f{}".format(i)
         for i in range(1, 13)
     }
     button_dictionary_10.update(caster_alphabet())

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -210,7 +210,7 @@ class Navigation(MergeRule):
         "space": "space"
     }
     button_dictionary_10 = {
-        "function {}".format(i): "f{}".format(i)
+        "F{}".format(i) : "f{}".format(i)
         for i in range(1, 13)
     }
     button_dictionary_10.update(caster_alphabet())

--- a/castervoice/rules/core/navigation_rules/nav2.py
+++ b/castervoice/rules/core/navigation_rules/nav2.py
@@ -37,12 +37,8 @@ class NavigationNon(MappingRule):
             R(Key("cs-f")),
         "replace":
             R(Key("c-h")),
-        "(F to | F2)":
-            R(Key("f2")),
-        "(F six | F6)":
-            R(Key("f6")),
-        "(F nine | F9)":
-            R(Key("f9")),
+        "F<function_key>":
+            R(Key("f%(function_key)s")),
         "[show] context menu":
             R(Key("s-f10")),
         "lean":
@@ -104,6 +100,7 @@ class NavigationNon(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
+        IntegerRefST("function_key", 1, 13),
         IntegerRefST("n", 1, 50),
         IntegerRefST("nnavi500", 1, 500),
         Choice("time_in_seconds", {


### PR DESCRIPTION
# Standardising function keys

<!-- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.-->

## Description
I replaced the 3 existing F-key mapping rules with one rule for all 12.

The old ones had alternative triggers with word numbers which I didn't add. I don't know if other users or speech recognition solutions struggle to differentiate between numerals and number words, but Dragon doesn't need them and it adds complexity. Let me know if you think it's worth implementing it and I'll do it.

I also added 'F<n>' alongside the 'function<n>' merge rule so it's all the same across the board.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
F-key implementation was inconsistent and the `function<n>` trigger is both cumbersome and might clash with other commands using the word "function".


## How Has This Been Tested
Manually testing a bunch of different commands using F-keys.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
