### PR TITLE
Trivial change: Fix vscode previous pane goes left

### DIFF
--- a/castervoice/rules/apps/editor/vscode_rules/vscode2.py
+++ b/castervoice/rules/apps/editor/vscode_rules/vscode2.py
@@ -162,7 +162,7 @@ class VSCodeNonCcrRule(MappingRule):
         "next pane":
             R(Key("c-k, c-right")),
         "(prior | previous | un) pane":
-            R(Key("c-k, c-right")),
+            R(Key("c-k, c-left")),
         "move tab left":
             R(Key("ca-left"),
             rdescript="VS Code: Move the current tab to the editor pane on the left."),


### PR DESCRIPTION
I think perhaps nobody used this command before... :-)
