### PR TITLE
Alter reboot command Kaldi

### DIFF
--- a/castervoice/lib/utilities.py
+++ b/castervoice/lib/utilities.py
@@ -199,7 +199,7 @@ def reboot():
     engine = get_current_engine()
     if engine.name == 'kaldi':
         engine.disconnect()
-        Popen([sys.executable, '-m', 'dragonfly', 'load-directory', '.', '--engine kaldi',  '--no-recobs-messages'])
+        Popen([sys.executable, '-m', 'dragonfly', 'load', '_caster.py', '--engine', 'kaldi',  '--no-recobs-messages'])
     if engine.name == 'sapi5inproc':
         engine.disconnect()
         Popen([sys.executable, '-m', 'dragonfly', 'load', '--engine', 'sapi5inproc', '_*.py', '--no-recobs-messages'])

--- a/castervoice/lib/utilities.py
+++ b/castervoice/lib/utilities.py
@@ -199,7 +199,7 @@ def reboot():
     engine = get_current_engine()
     if engine.name == 'kaldi':
         engine.disconnect()
-        Popen([sys.executable, '-m', 'dragonfly', 'load', '_caster.py', '--engine', 'kaldi',  '--no-recobs-messages'])
+        Popen([sys.executable, '-m', 'dragonfly', 'load', '_*.py', '--engine', 'kaldi',  '--no-recobs-messages'])
     if engine.name == 'sapi5inproc':
         engine.disconnect()
         Popen([sys.executable, '-m', 'dragonfly', 'load', '--engine', 'sapi5inproc', '_*.py', '--no-recobs-messages'])


### PR DESCRIPTION
# Alter reboot command Kaldi

## Description

This pull request changes the command used to reboot caster when using the Kaldi engine. It did not work for me before making this alteration.

## How Has This Been Tested

Trying "reboot caster" both before and after making this change.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes. Is a test for this feasible? Do we have Kaldi set up in CI?
- [ ] All new and existing tests pass. 

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.