### PR TITLE
New command to scroll mouse wheel continuously

### DIFF
--- a/castervoice/rules/core/navigation_rules/nav2.py
+++ b/castervoice/rules/core/navigation_rules/nav2.py
@@ -53,6 +53,11 @@ class NavigationNon(MappingRule):
             R(Function(navigation.curse)),
         "scree <direction> [<nnavi500>]":
             R(Function(navigation.wheel_scroll)),
+        "zinc <direction> <time_in_seconds>":
+            R(AsynchronousAction(
+                [L(S(["cancel"], Function(navigation.wheel_scroll, nnavi500=1)))],
+                repetitions=1000,
+                blocking=False)),
         "colic":
             R(Key("control:down") + Mouse("left") + Key("control:up")),
         "garb [<nnavi500>]":

--- a/castervoice/rules/core/navigation_rules/nav2.py
+++ b/castervoice/rules/core/navigation_rules/nav2.py
@@ -53,7 +53,7 @@ class NavigationNon(MappingRule):
             R(Function(navigation.curse)),
         "scree <direction> [<nnavi500>]":
             R(Function(navigation.wheel_scroll)),
-        "zinc <direction> <time_in_seconds>":
+        "scree <direction> <time_in_seconds>":
             R(AsynchronousAction(
                 [L(S(["cancel"], Function(navigation.wheel_scroll, nnavi500=1)))],
                 repetitions=1000,

--- a/docs/readthedocs/Caster_Commands/Mouse.md
+++ b/docs/readthedocs/Caster_Commands/Mouse.md
@@ -24,6 +24,9 @@ A video demonstration of mouse commands is found [here](https://youtu.be/UISjQBM
     - `<direction>` can be _sauce_ (up), _dunce_ (down), _lease_ (left), or _ross_ (right).
 - Scroll mouse wheel: `scree <direction> [number_of_scrolls]`
     - `<direction>` can be _sauce_ (up) or _dunce_ (down).
+- Scroll mouse wheel continuously (until you say `cancel`): `zinc <direction> <scroll speed>`
+    - `<direction>` can be _sauce_ (up) or _dunce_ (down).
+    - `<scroll speed>` can be _super slow_, _slow_, _normal_, or _supefast_
 
 **Examples**:
 


### PR DESCRIPTION


# New command to scroll mouse wheel continuously

## Description

Initiate scrolling as an asynchronous action until the user says `cancel`.

command is `zinc sauce|dunce <speed>` where speed is one of super slowly, slowly, normal, fast and superfast.

## Motivation and Context

I got tired of saying "scree dunce" repeatedly when I didn't know how far I wanted to scroll.
The existing `<direction> <time_in_seconds>` command does a similar thing, except that it moves the cursor while doing so.
The VSCode "scroll up/down" and "scroll page down/up" commands do a similar thing in that they don't move the cursor, but they do not operate continuously.

I chose the name zinc because it seems unique and Dragon is good at picking up the `z` sound.

## How Has This Been Tested

I have tested the new command in VS code and chrome. In both cases it initiated scrolling in the correct direction and cancelled appropriately. I have only tested using Dragon

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [x] New documentation is clear and complete.
- [x] Code is clear and readable.
