### PR TITLE
Trivial change: Four new Rust syntax commands

### DIFF
--- a/castervoice/rules/ccr/rust_rules/rust.py
+++ b/castervoice/rules/ccr/rust_rules/rust.py
@@ -111,6 +111,14 @@ class Rust(MergeRule):
             R(Text("self")),
         "brace pan":
             R(Key("escape, escape, end, left, enter, enter, up, tab")),
+        "enum":
+            R(Text("enum ")),
+        "await":
+            R(Text(".await")),
+        "async":
+            R(Text("async ")),
+        "clone":
+            R(Text(".clone()")),
         "name space":
             R(Key("colon, colon")),
     }


### PR DESCRIPTION

# Trivial Change: Four new Rust commands

## Description

`enum` , `async`, and `await` are often misrecognized by dragon,
so having extra commands for them reduces frustrationand can.
The clone command is just a quick shortcut.
