### PR TITLE
`stun` command for control enter

### DIFF
--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -84,6 +84,8 @@ class Navigation(MergeRule):
             R(Key("c-s"), rspec="save"),
         'shock [<nnavi50>]':
             R(Key("enter"), rspec="shock")*Repeat(extra="nnavi50"),
+        'stun [<nnavi50>]':
+            R(Key("c-enter"), rspec="stun")*Repeat(extra="nnavi50"),
         # "(<mtn_dir> | <mtn_mode> [<mtn_dir>]) [(<nnavi500> | <extreme>)]":
         #     R(Function(text_utils.master_text_nav)), # this is now implemented below
         "shift click":


### PR DESCRIPTION
# `stun` command for control enter

## Description

Insert a ctrl+enter into the editor.

## Motivation and Context

Several applications and web sites use ctrl+enter for inserting a new line without submitting a form or for submitting a form instead of a newline (go figure). I use it in the VSCode commit editor, github input boxes, facebook, and my work chat application.

I chose `stun` for it's analogy to `shock`

## How Has This Been Tested

I've been using it for a while in several applications.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

Note: I didn't update the documentation because "shock" is only seen in the cheat sheet, and I'm reluctant to change the layout in a LaTeX document.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
