### PR TITLE
Add command to open line above

### DIFF
--- a/castervoice/lib/navigation.py
+++ b/castervoice/lib/navigation.py
@@ -222,13 +222,24 @@ def curse(direction, direction2, nnavi500, dokick):
         elif int(dokick) == 2:
             right_click()
 
+def previous_line(semi):
+    semi = str(semi)
+    Key("escape").execute()
+    time.sleep(0.05)
+    Key("end").execute()
+    time.sleep(0.05)
+    Text(semi).execute()
+    time.sleep(0.05)
+    Key("up").execute()
+    time.sleep(0.05)
+    Key("enter").execute()
 
 def next_line(semi):
     semi = str(semi)
     Key("escape").execute()
-    time.sleep(0.07)
+    time.sleep(0.05)
     Key("end").execute()
-    time.sleep(0.07)
+    time.sleep(0.05)
     Text(semi).execute()
     Key("enter").execute()
 

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -106,6 +106,8 @@ class Navigation(MergeRule):
             R(Key("home/5, s-end"), rspec="shackle"),
         "(tell | tau) <semi>":
             R(Function(navigation.next_line), rspec="tell dock"),
+        "(hark | heart) <semi>":
+            R(Function(navigation.previous_line), rspec="hark dock"),
         "duple [<nnavi50>]":
             R(Function(navigation.duple_keep_clipboard), rspec="duple"),
         "Kraken":


### PR DESCRIPTION
I'm not sure if this is generally useful, so feel free to close.

This command adds a character at the end of the current line
and then insert a new line above.

It is symmetric to the `tell` command, which does the same thing,
except
goes below the current line.

both commands are analogous to the o and O commands in vim.

I chose `hark` as it is kind of the inverse of `tell`,
but dragon often hears it as `heart`, so I used both.
