### PR TITLE
content_request_generator handles special characters UTF-8 py3

### DIFF
--- a/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
+++ b/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
@@ -32,7 +32,7 @@ class ContentRequestGenerator(object):
     def _get_file_lines(self, file_path):
         """File i/o broken out for testability"""
         content = None
-        with open(file_path) as f:
+        with open(file_path, encoding="UTF-8") as f:
             content = f.readlines()
         return content
 

--- a/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
+++ b/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
@@ -33,7 +33,7 @@ class ContentRequestGenerator(object):
     def _get_file_lines(self, file_path):
         """File i/o broken out for testability"""
         content = None
-        with open(file_path) as f:
+        with open(file_path, encoding="utf8") as f:
             content = f.readlines()
         return content
 

--- a/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
+++ b/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
@@ -1,6 +1,8 @@
 import re
 import os
-from io import open
+import six
+if six.PY2:
+    from io import open
 
 from castervoice.lib.ctrl.mgr.loading.load.content_request import ContentRequest
 from castervoice.lib.ctrl.mgr.loading.load.content_type import ContentType

--- a/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
+++ b/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
@@ -32,7 +32,7 @@ class ContentRequestGenerator(object):
     def _get_file_lines(self, file_path):
         """File i/o broken out for testability"""
         content = None
-        with open(file_path, encoding="UTF-8") as f:
+        with open(file_path) as f:
             content = f.readlines()
         return content
 

--- a/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
+++ b/castervoice/lib/ctrl/mgr/loading/load/content_request_generator.py
@@ -1,5 +1,6 @@
 import re
 import os
+from io import open
 
 from castervoice.lib.ctrl.mgr.loading.load.content_request import ContentRequest
 from castervoice.lib.ctrl.mgr.loading.load.content_type import ContentType


### PR DESCRIPTION
# Trivial change

This one fixes a bug I was seeing when using python 3 with a user file containing special characters.