### PR TITLE
Two minor tweaks for vscode grammar (should be trivial)

### DIFF
--- a/castervoice/rules/apps/editor/vscode_rules/vscode.py
+++ b/castervoice/rules/apps/editor/vscode_rules/vscode.py
@@ -30,8 +30,6 @@ class VSCodeCcrRule(MergeRule):
         "scroll page down [<n>]":
             R(Key("a-pgdown")*Repeat(extra='n'),
               rdescript="VS Code: Scroll Down One Page Down At a Time"),
-        "(unindent|out dent) [<n>]":
-            R(Key("home, s-tab:%(n)s"), rdescript="VS Code: Unindent"),
         "comment [line]":
             R(Key("c-slash"), rdescript="VS Code: Line Comment"),
         "block comment":
@@ -89,8 +87,14 @@ class VSCodeCcrRule(MergeRule):
         "next cursor [<n>]":
             R(Key("c-d")*Repeat(extra='n'),
               rdescript="VS Code: Add Cursor to Next Occurrence of Current Selection"),
+        "skip next cursor [<n>]":
+            R(Key("c-k,c-d") * Repeat(extra="n"),
+            rdescript="VS Code: Skip Selection and Add Cursor to Next Occurrence of Current Selection",
+        ),
         "indent [<n>]":
-            R(Key("home, tab:%(n)s"), rdescript="VS Code: Indent"),
+            R(Key("c-]"), rdescript="VS Code: Indent"),
+        "(unindent|out dent) [<n>]":
+            R(Key("c-["), rdescript="VS Code: Unindent"),
         "hard delete [<n>]":
             R(Key("s-del"), rdescript="VS Code: Eliminates Line not Just the Text on it"),
         "copy line up [<n>]":

--- a/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
@@ -616,16 +616,18 @@ Same Commands as [Git Bash](#git-bash)
 
 | Command                      | Command                                   | Command                                 |
 | :--------------------------- | :---------------------------------------- | :-------------------------------------- |
-| `scroll up [<n>]`            | `scroll down [<n>]`                       | `scroll page up [<n>]`                  |
-| `scroll page down [<n>]`     | `(Unindent/outdent) [<n>]`                | `Comment line`                          |
-| `Block comment`              | `cursor above [<n>]`                      | `cursor below [<n>]`                    |
-| `remove cursor`              | `tall cursor up`                          | `tall cursor down`                      |
-| `select [in] brackets [<n>]` | `all current selection`                   | `all current word`                      |
-| `select next [<n>]`          | `go to next [<n>]`                        | `select prior [<n>]`                    |
-| `go to prior [<n>]`          | `cursor all`                              | `next cursor [<n>]`                     |
-| `indent [<n>]`               | `hard delete [<n>]`                       | `copy line up [<n>]`                    |
-| `copy line up [<n>]`         | `switch line down [<n>]`                  | `switch line up [<n>]`                  |
-| `match bracket`              | `select between <between_parables> [<n>]` | `select around <around_parables> [<n>]` |
+| `scroll up [<n>]`            | `scroll page up [<n>]`                    | `Comment line`                          |
+| `scroll down [<n>]`          | `scroll page down [<n>]`                  | `Block comment`                         |
+| `cursor above [<n>]`         | `cursor all`                              | `tall cursor up`                        |
+| `cursor below [<n>]`         | `remove cursor`                           | `tall cursor down`                      |
+| `select [in] brackets [<n>]` | `all current selection`                   | `go to next [<n>]`                      |
+| `select next [<n>]`          | `next cursor [<n>]`                       | `go to prior [<n>]`                     |
+| `select prior [<n>]`         | `skip next cursor [<n>]`                  | `copy line down [<n>]`                  |
+| `indent [<n>]`               | `all current word`                        | `copy line up [<n>]`                    |
+| `(Unindent/outdent) [<n>]`   | `select around <around_parables> [<n>]`   | `switch line up [<n>]`                  |
+| `match bracket`              | `select between <between_parables> [<n>]` | `switch line down [<n>]`                |
+| `hard delete [<n>]`          | 
+
 
 ## Non-CCR
 


### PR DESCRIPTION
1. Use the explicit indent and unindent VSCode commands
    instead of simulating with home + tab.

    The built-in commands work correctly with multiple cursors.

2. VSCode command to "skip next" the current cursor

    This behaves like "next cursor" except that it removes the
    current word from the selection.

    This allows you to use next cursor interactively
    such that you don't have to select all the words in a row.
