### PR TITLE
"Remedy" Dialogue (request for comment)

### DIFF
--- a/castervoice/asynch/corrections/manager.py
+++ b/castervoice/asynch/corrections/manager.py
@@ -1,0 +1,103 @@
+"""
+Manager for the corrections window. This module runs in the 
+Caster process. Its primary purpose is to initialize, manage, and communicate
+with the process that is actively displaying the window.
+
+The new process is initialized using multiprocessing.
+It is initialized as caster starts so there is no startup cost
+at the time the user asks to display the window.
+The window can be reused so the process never has to stop.
+"""
+import threading
+from castervoice.lib import control
+from castervoice.lib.context import paste_string_without_altering_clipboard
+from castervoice.lib import settings
+from dragonfly import Pause, Window
+from multiprocessing import get_context, Process, Pipe
+from .process import window_manager
+
+GRAMMAR_ENABLED = False
+
+def choice_grammar_enabled():
+    return GRAMMAR_ENABLED
+
+def set_enabled(enabled: bool):
+    global GRAMMAR_ENABLED
+    GRAMMAR_ENABLED = True
+
+# If the user hasn't made a selection in 15 seconds,
+# instruct the subprocess to hide the remedy window.
+WAIT_FOR_CHOICE_TIMEOUT = 15
+
+# Instruct the multi- processing library to use pythonw
+# for spawning tasks. Otherwise it tries to boot new copy of DNS.
+#
+# TODO: This shouldn't run at the script level
+
+# Caster probably has some initialization hooks to use instead
+# The setting needs only be set once, even if we use this
+# structure for other async commands (eg the mouse grids)
+pythonw = settings.settings(["paths", "PYTHONW"])
+get_context("spawn").set_executable(pythonw)
+
+# Start a new process initialized from the window_manager function
+# in the process module. All communication happens over a subprocess pipe.
+(PIPE, SUB_PIPE) = Pipe()
+WINDOW_PROCESS = Process(target=window_manager, args=(SUB_PIPE,))
+WINDOW_PROCESS.start()
+
+
+def send_choice(choice):
+    """
+    Instruct the corrections window process that a user choice has been selected.
+    """
+    PIPE.send(("SELECT CHOICE", choice))
+
+
+def cancel():
+    """
+    Instruct the corrections window process that the user has said "cancel"
+    So it can hide the window.
+    """
+    PIPE.send(("CANCEL", ""))
+
+
+def query_user_for_choice(selected_text):
+    """
+    Start a thread to show the corrections window and wait for the user to
+    select a choice.
+    """
+    threading.Thread(target=wait_for_choice, args=(selected_text,)).start()
+
+
+
+def wait_for_choice(selected_text):
+    """
+    Function running in a thread to tell the subprocess module to
+    show the window with the appropriate choices.
+    Then wait for the window to inform us which choice the user selected,
+    and replace the current selection with whatever they chose.
+    Thread ends if the user doesn't make a choice within a set number of seconds.
+    """
+    set_enabled(True)
+
+    while PIPE.poll():
+        # It is possible there are cancel messages in the pipe
+        # from the previous run. Remove them to get into a known state
+        # before showing the window again.
+        (message_type, message) = PIPE.recv()
+        if message_type != "CANCEL":
+            print("unexpected value in pipe")
+    PIPE.send(("SHOW WINDOW", selected_text))
+
+    if PIPE.poll(WAIT_FOR_CHOICE_TIMEOUT):
+        (message_type, message) = PIPE.recv()
+        print(f"Got a message {message_type}, {message}")
+        if message_type == "CHOICE":
+            paste_string_without_altering_clipboard(message)
+        elif message_type == "CANCEL":
+            print("Corrections dialogue closed by user")
+    else:
+        print("Timed out waiting for choice")
+        PIPE.send(("CANCEL", ""))
+    set_enabled(False)

--- a/castervoice/asynch/corrections/process.py
+++ b/castervoice/asynch/corrections/process.py
@@ -41,7 +41,7 @@ class App(QtCore.QObject):
     for instructions from the multiprocessing pipe.
     '''
     def __init__(self, pipe, parent=None):
-        super(self.__class__, self).__init__(parent)
+        super().__init__(parent)
 
         self.window = Window()
         self.pipe_loop = PipeLoop(pipe)
@@ -73,7 +73,7 @@ class PipeLoop(QtCore.QThread):
     hideWindow = QtCore.Signal()
 
     def __init__(self, pipe, parent=None):
-        super(self.__class__, self).__init__(parent)
+        super().__init__(parent)
         self.pipe = pipe
 
     def run(self):

--- a/castervoice/asynch/corrections/process.py
+++ b/castervoice/asynch/corrections/process.py
@@ -1,0 +1,214 @@
+'''
+This module lives in a subprocess and communicates with the main caster process
+over a multiprocessing pipe.
+
+It's primary purpose is to show and hide the window with a list of corrections
+and ensure that it contains the correct list of corrections depending on
+instructions sent from the manager module.
+
+the list of similar sounding words comes from an index that I created
+and curate in the similar_sounding_words python package.
+'''
+from PySide2 import QtWidgets, QtCore
+import similar_sounding_words
+from functools import partial
+
+try:
+    # Tip: because this module runs in the subprocess its logging output gets eaten
+    # `pip install q`
+    # then `tail -f /c/Users/<you>/AppData/Local/Temp/q` in `git-bash`
+    # See https://github.com/zestyping/q for more useful stuff
+    import q
+
+    print = q
+except ImportError:
+    pass
+
+def window_manager(pipe):
+    '''
+    Entry-point for the subprocess. Initializes a Qt application, but does not
+    show the window. This function is called at program startup.
+    '''
+    qtapp = QtWidgets.QApplication()
+    app = App(pipe, qtapp)
+    qtapp.exec_()
+
+
+
+class App(QtCore.QObject):
+    '''
+    Main QT application that sets up the window and the thread that listens
+    for instructions from the multiprocessing pipe.
+    '''
+    def __init__(self, pipe, parent=None):
+        super(self.__class__, self).__init__(parent)
+
+        self.window = Window()
+        self.pipe_loop = PipeLoop(pipe)
+        self.window.cancelClicked.connect(self.pipe_loop.cancel)
+        self.window.clickChoice.connect(self.pipe_loop.setChoice)
+        self.pipe_loop.setChoices.connect(self.window.setChoices)
+        self.pipe_loop.showWindow.connect(self.window.show)
+        self.pipe_loop.hideWindow.connect(self.window.hide)
+        self.parent().aboutToQuit.connect(self.forceLoopQuit)
+
+        self.pipe_loop.start()
+
+    def forceLoopQuit(self):
+        '''
+        Make sure we don't keep any threads hanging around if we unexpectedly quit.
+        '''
+        if self.pipe_loop.isRunning():
+            self.pipe_loop.terminate()
+            self.pipe_loop.wait()
+
+
+class PipeLoop(QtCore.QThread):
+    '''
+    QT worker thread that just listens for instructions from the pipe and emits
+    QT signals to the window when it receives them.
+    '''
+    setChoices = QtCore.Signal(list)
+    showWindow = QtCore.Signal()
+    hideWindow = QtCore.Signal()
+
+    def __init__(self, pipe, parent=None):
+        super(self.__class__, self).__init__(parent)
+        self.pipe = pipe
+
+    def run(self):
+        choices = []
+        while True:
+            (message_type, message) = self.pipe.recv()
+            print(
+                f"Received corrections window message {message_type}, {message}"
+            )
+            if message_type == "SELECT CHOICE":
+                choice_index = message - 1
+                if choice_index < len(choices):
+                    self.pipe.send(("CHOICE", choices[choice_index]))
+                    choices = []
+                    self.hideWindow.emit()
+            elif message_type == "SHOW WINDOW":
+                choices = get_choices(message)
+                self.setChoices.emit(choices)
+                self.showWindow.emit()
+            elif message_type == "CANCEL":
+                self.hideWindow.emit()
+                choices = []
+
+    @QtCore.Slot()
+    def cancel(self):
+        self.pipe.send(("CANCEL", ""))
+
+    @QtCore.Slot()
+    def setChoice(self, text):
+        print("got choice", text)
+        self.pipe.send(("CHOICE", text))
+        self.hideWindow.emit()
+
+
+class Window(QtWidgets.QDialog):
+    '''
+    The correction window is instantiated on program startup, but it does not
+    get displayed until the user has requested a correction.
+    '''
+    cancelClicked = QtCore.Signal()
+    clickChoice = QtCore.Signal(str)
+
+    def __init__(self):
+        QtWidgets.QDialog.__init__(self)
+        self.setWindowTitle("Remedy")
+        self.setAttribute(QtCore.Qt.WA_QuitOnClose, False)
+        self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
+
+        self.layout = QtWidgets.QGridLayout()
+        self.setLayout(self.layout)
+
+    @QtCore.Slot(str, list)
+    def setChoices(self, choices):
+        '''
+        When the user has requested a correction, we need to display the choices
+        in a window. It each word that can be displayed comes in three flavours
+        based on desired capitalization. We use QTs rich text formatting
+        to display the first of each group in bold and insert a newline
+        after the third member of the group so it's easier to visually scan
+        for the desired correction.
+
+        This lot is connected to the `setChoices` signal on the PipeLoop.
+        '''
+        clearLayout(self.layout)
+        for i, choice in enumerate(choices):
+            label = QtWidgets.QPushButton(f"{i+1}. {choice}")
+            if i % 3 == 0:
+                label.setStyleSheet("font:bold;border-style:none")
+            elif i % 3 == 2:
+                label.setStyleSheet("padding-bottom:5ex;border-style:none")
+            else:
+                label.setStyleSheet("border-style:none")
+            label.clicked.connect(partial(self.clickChoice.emit, choice))
+            self.layout.addWidget(label, i % 9, i // 9, 1, 1)
+
+    def reject(self):
+        '''
+        Called when the user manually closes the window using the X button.
+        '''
+        print("Dialogue closed")
+        self.hide()
+        self.cancelClicked.emit()
+
+
+def clearLayout(layout):
+    '''
+    Helper function to remove all of the children from the window
+    before displaying the new choices. It is astonishing that QT does not have
+    built-in support for this.
+    '''
+    child = layout.takeAt(0)
+    while child:
+        if child.widget() is not None:
+            child.widget().deleteLater()
+        elif child.layout() is not None:
+            clearLayout(child.layout())
+        child = layout.takeAt(0)
+
+
+def get_choices(selection):
+    '''
+    Look up related words in the similar sounding words index and create a
+    group of choices based on these words. Each word gets three options
+    for the three different capitalization levels (lower, UPPER, and Title).
+    '''
+    selection = selection.lower()
+    alternates = [selection] + similar_sounding_words.index.get(selection, [])
+    capitalizations = (
+        (word.lower(), word.title(), word.upper()) for word in alternates
+    )
+    return [word for capitalization in capitalizations for word in capitalization]
+
+
+
+# super dirty test sequence so I don't have to restart caster for every bug
+if __name__ == "__main__":
+    import multiprocessing, time
+
+    (PIPE, SUB_PIPE) = multiprocessing.Pipe()
+    process = multiprocessing.Process(
+        target=window_manager, args=(SUB_PIPE,), daemon=True
+    )
+    process.start()
+    print("Process is running")
+    print("Process is running")
+    PIPE.send(("SHOW WINDOW", "or"))
+    time.sleep(10)
+    print("Sending select choice")
+    PIPE.send(("SELECT CHOICE", 2))
+    time.sleep(2)
+    print("waiting for something")
+    print(PIPE.recv())
+    print(" trying to send show window again")
+    PIPE.send(("SHOW WINDOW", "other"))
+    time.sleep(2)
+    print("sending a cancel")
+    PIPE.send(("CANCEL", ""))
+    time.sleep(2)

--- a/castervoice/lib/const.py
+++ b/castervoice/lib/const.py
@@ -20,7 +20,7 @@ CORE = [
     "HMCRule", "HMCConfirmRule", "HMCDirectoryRule",
     "HMCHistoryRule", "HMCLaunchRule", "HMCSettingsRule",
     # GUI Rules
-    "HistoryRule", "ChainAlias", "Alias",
+    "HistoryRule", "ChainAlias", "Alias", "CorrectionsWindowRule"
     # other common rules
     "BringRule", "Again"
     ]

--- a/castervoice/rules/core/text_manipulation_rules/corrections.py
+++ b/castervoice/rules/core/text_manipulation_rules/corrections.py
@@ -1,0 +1,107 @@
+from dragonfly import MappingRule, Function, Dictation, Choice
+from castervoice.lib.merge.state.short import R
+from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
+from castervoice.lib.context import read_selected_without_altering_clipboard
+from castervoice.asynch.corrections.manager import query_user_for_choice
+from castervoice.rules.core.text_manipulation_rules import (
+    text_manipulation_support as tm,
+)
+from castervoice.lib.merge.additions import IntegerRefST
+import similar_sounding_words
+from castervoice.lib import control
+
+
+def correct_selected():
+    """
+    If there is any text selected, show the corrections window and
+    allow the user to replace it.
+    Returns False if there is no text selected.
+    """
+    selected_text = read_selected_without_altering_clipboard(True)
+    if selected_text[0] == 2 or not selected_text[1]:
+        return False
+    else:
+        selected_text = selected_text[1]
+    query_user_for_choice(selected_text)
+    return True
+
+
+def correct_dictation(
+    dictation, direction, number_of_lines_to_search, occurrence_number
+):
+    """
+    Using the same search rules is the text manipulation commands,
+    search for a matching word, and try to select it and show the corrections window.
+    if the spoken word cannot be found, it will try to find any similar sounding words
+    initial the corrections box for that instead.
+    """
+    application = tm.get_application()
+    if direction == "up" or direction == "down":
+        number_of_lines_to_search, direction = tm.deal_with_up_down_directions(direction, number_of_lines_to_search)
+    text = tm.select_text_and_return_it(direction, number_of_lines_to_search, application)
+    if not text:
+        return 
+    phrase = dictation.strip().lower()
+    alternatives = [phrase] + similar_sounding_words.index.get(phrase, [])
+    for phrase in alternatives:
+        # TODO: Behaviour when there are multiple matches in the selected text
+        # may not be expected
+        positions = tm.get_start_end_position(text, phrase, direction, occurrence_number, "dictation")
+        if not positions:
+            continue
+        left_index, right_index = positions
+        tm.deal_with_inner_select(text, phrase, left_index, right_index, application)
+        if correct_selected():
+            break
+    else:
+        print("unable to find", alternatives)
+
+
+class CorrectionsRule(MappingRule):
+    """
+    Rules for displaying the corrections window allowing a user to choose
+    an alternate word or capitalization for the one that is selected.
+    """
+
+    mapping = {
+        "fix (selected|selection)": R(
+            Function(correct_selected), rdescript="Correct selected word"
+        ),
+        "fix [<direction>] [<number_of_lines_to_search>] [<occurrence_number>] <dictation>": R(
+            Function(correct_dictation), rdescript="Correct dictated word",
+        ),
+    }
+
+    extras = [
+        Dictation("dictation"),
+        IntegerRefST("number_of_lines_to_search", 1, 50),
+        Choice(
+            "occurrence_number",
+            {
+                "first": 1,
+                "second": 2,
+                "third": 3,
+                "fourth": 4,
+                "fifth": 5,
+                "sixth": 6,
+                "seventh": 7,
+                "eighth": 8,
+                "ninth": 9,
+                "tenth": 10,
+            },
+        ),
+        Choice(
+            "direction",
+            {"lease": "left", "ross": "right", "sauce": "up", "dunce": "down",},
+        ),
+    ]
+    defaults = {
+        "direction": "left",
+        "number_of_lines_to_search": 0,
+        "occurrence_number": 1,
+    }
+
+
+def get_rule():
+    details = RuleDetails(name="text corrections")
+    return CorrectionsRule, details

--- a/castervoice/rules/core/text_manipulation_rules/corrections_window.py
+++ b/castervoice/rules/core/text_manipulation_rules/corrections_window.py
@@ -1,0 +1,27 @@
+from dragonfly import MappingRule, Function, Choice
+from castervoice.lib.merge.additions import IntegerRefST
+from castervoice.lib.merge.state.short import R
+from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
+from castervoice.asynch.corrections.manager import send_choice, cancel, choice_grammar_enabled
+
+
+
+class CorrectionsWindowRule(MappingRule):
+    """
+    Rules to be invoked when the corrections window is displayed.
+    They are forwarded into the process that is met and edging the corrections window
+    so that it can respond appropriately.
+    """
+
+    mapping = {
+        "cancel": R(Function(cancel)),
+        "choose <choice>": R(Function(send_choice)),
+    }
+    extras = [
+        IntegerRefST("choice", 0, 100),
+    ]
+
+
+def get_rule():
+    details = RuleDetails(name="corrections window", function_context=choice_grammar_enabled)
+    return CorrectionsWindowRule, details

--- a/castervoice/rules/core/text_manipulation_rules/text_manipulation_support.py
+++ b/castervoice/rules/core/text_manipulation_rules/text_manipulation_support.py
@@ -390,12 +390,13 @@ def select_phrase(phrase, direction, number_of_lines_to_search, occurrence_numbe
     match_index = get_start_end_position(selected_text, phrase, direction, occurrence_number, dictation_versus_character)
     if match_index:
         left_index, right_index = match_index
+        deal_with_inner_select(selected_text, phrase, left_index, right_index, application)
     else:
         # phrase not found
         deal_with_phrase_not_found(selected_text, application, direction)
-        return
-    
         
+    
+def deal_with_inner_select(selected_text, phrase, left_index, right_index, application):
     # Approach 1: paste the selected text over itself rather than simply unselecting. A little slower but works Texstudio
     # TODO: change this so that it unselects by pressing left and then right rather than pasting over the top
     if application == "texstudio":

--- a/docs/readthedocs/Caster_Commands/Text_Manipulation.md
+++ b/docs/readthedocs/Caster_Commands/Text_Manipulation.md
@@ -49,7 +49,46 @@ Caster provides powerful text manipulation and navigation features. These functi
   - change the 2nd instance of the word "multiple" in the next 3 lines to "Multiple"
 - _capital ross lower multiple_
   - change the next instance of the word "Multiple" to "multiple"
-  
+
+## Corrections Window
+
+Caster supports commonly misheard dictation and incorrect capitalizations
+using the corrections window.
+
+There are two ways to invoke it. The simplest is to select a single word using
+the mouse, keyboard, or one of the grab commands described above.
+
+Then say _remedy selection_ or _remedy selected_ to bring up a list of possible corrections
+for the selected word. The corrections will include variations on capitalizations of that word
+as well as lists of any words that are known to sound similar or be confused with the one that
+selected. This includes common homophones, different spellings of numbers, and words
+that have been contributed by the Caster community.
+
+For example, if you select the word "or" and then say "remedy or", it will show a window
+that looks like this:
+
+![or corrections](https://i.postimg.cc/63jWsDmJ/or-corrections.jpg)
+
+The window is divided to make it easy to distinguish different words and
+three capitalization options for lower, upper, and title cases.
+
+Each of the options has been assigned a number. To replace the selection with one of the
+words in the box, simply say _choose [number]_. If none of the options is suitable,
+say _cancel_ to dismiss the box. The word will remain selected so you can replace it
+with alternative means such as other dictation or the keyboard.
+
+you can also display the corrections box if there is no selected text. The easiest is to 
+say _remedy word_ which will find the nearest instance of that word to the left of the cursor.
+If Caster can't find the word it hears, it will also search for other words that sound
+like it using the same dictionary.
+
+If that doesn't allow you to select and correct the word that you are interested in,
+the remedy command also accepts optional arguments similar to those used for _grab_
+as described above. For example you could say _remedy ross eight second in_ to
+show the corrections dialogue for the second instance of the word "in"
+in the eight lines to the right of and below the cursor.
+
+    
 ## Possible future features
 
 Please feel free to try and implement these and submit a pull request!

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,5 @@ appdirs>=1.4.3
 scandir>=1.10.0
 pylint
 pyvda==0.0.8
+similar-sounding-words
 six

--- a/requirements-mac-linux.txt
+++ b/requirements-mac-linux.txt
@@ -7,4 +7,5 @@ appdirs>=1.4.3
 scandir>=1.10.0
 pylint
 PySide2
+similar-sounding-words
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pyvda==0.0.8
+similar-sounding-words
 six


### PR DESCRIPTION
## Short version

Say *remedy in* and get the following dialogue:

![image](https://user-images.githubusercontent.com/86920/82126732-edd72a80-9784-11ea-927d-725cbad713ac.png)

Then say *Choose 5* and the word "in" will be replaced with the word "Inn," in title case.

## Long version
This is a first pass at a corrections dialogue. My goal was to pop up a window when the user says "remedy selection" and display possible corrections for the selected word.

There are two commands, `remedy selection` shows the corrections window for whatever word is actively selected. `remedy <text manipulation args> <dictation>`  uses the text_manipulation select functions to select the active word before showing the window. It has an added feature where if it can't find the selection that it appears, it searches for any alternative words that are index of similar sounding words. This allows you to say, for example `remedy to` and it will initiate correction for any of `to`, `too`, or `two` that it finds. This is a big advantage compared to the `replace` commands, which demand that the text you want to replace be exactly what dragon recognizes.

Currently, the suggestions include differing capitalizations, and words that sound the same using a list that I crafted from various lists of homophones on the web. that list lives in a new project [here](https://github.com/dusty-phillips/similar-sounding-words). I was expecting to try to do something that used the sentence and context with some natural language processing, but this basic index is way faster, and actually seems to be more useful.

This PR is built in QT and depends on Python 3. I'm not really interested in maintaining a Python 2 port.

I had to develop a different mechanism for communicating with the open window then the XML RPC tooling that is used in the mouse grid dialogues. It needs to be really snappy in order to be useful, and the cost of starting a full new Python process, initializing a TCP connection, and constructing a new window was taking simply too much time.

Instead, I depended on the multiprocessing library, which is rocksolid and lightning fast since Python 3.4. I open the process when Caster begins so that it is ready to go when I ask for a correction. I also have the cutie app and window initialized so all that needs to be done when the user requests a connection is put the requested choices into the dialogue and show it. The time between Caster recognizing the command in the window being actively displayed is more or less instantaneous. I actually suggest that a similar model could be used to speed up the most great commands.

The project is essentially split into four files. there are two rule files: A global one `text_manipulation_rules/corrections.py` that waits for the user to request a remedy, and a window-specific one `text_manipulation_rules/corrections_window.py` that is used for the user to initiate a choice. then there is a `asynch/corrections/manager.py` did is responsible for sending instructions to the subprocess that contains the window, and `async/corrections/process.py` which runs in the sub process to receive those commands.

## Open Questions
 - [ ] Currently, I am initializing the multi-processing spawner in the corrections manager module. This only needs to be done once, and if this model is used for other Windows, it should probably be done at a different Caster initialization step.
 - [ ] Is this something that you would want to include in Caster, or should I consider releasing it as a separate 'Caster plug-in' project? if you would want Python 2 support, I would probably choose to do that instead of maintaining it.
 - [ ] Are there better or additional ways to find related words? @Danesprite was looking into piping dragons related words through dragonfly, but we determined that Dragon's API wasn't returning very comprehensive results. I tried to do something with AutoCorrect libraries, but found that they weren't very useful, and I've been wondering about doing something with Markov chains.
 - [ ] Behaviour when there are multiple instances of similar sounding words in the the selection may be unexpected, but it's not clear what it should be. For example in the sentence, "She dragged the ore through the oar, or it would have been lost," If you say "Remedy leap second or", it's not clear which of "or," "oar", and "ore" you want to chang.
 - [ ] I have tested this pretty thoroughly with every manner of race condition an error condition I could think of, and I've been using it for daily use for a couple of days. But I don't think it's ready for prime time without some additional testing from other environments.
 - [ ] Speaking of other environments, I haven't tried it with Kaldi, WSR, or operating systems other than Windows 10.
 - [ ] If you want to accept this into Caster, I will write some documentation.

For me, this has already been a game changer, and made drafting, for example, this post much less frustrating than it would otherwise have been! ☺️

let me know if you have any ideas or suggestions. If you don't think it's a good fit for Caster (I know it's more useful for general dictation than for coding anyway), I am happy to maintain it as a separate package.


