### PR TITLE
Fix dragonfly `FuncContext` Caster App integration

### DIFF
--- a/castervoice/lib/ctrl/mgr/rule_maker/mapping_rule_maker.py
+++ b/castervoice/lib/ctrl/mgr/rule_maker/mapping_rule_maker.py
@@ -25,7 +25,7 @@ class MappingRuleMaker(BaseRuleMaker):
 
         context = None
         if details.function_context is not None:
-            context = FuncContext(function=details.function_context, executable=details.executable, title=details.title)
+            context = AppContext(executable=details.executable, title=details.title) & FuncContext(function=details.function_context)
         else:
             if details.executable is not None or details.title is not None:
                 context = AppContext(executable=details.executable, title=details.title)

--- a/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
+++ b/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
@@ -150,11 +150,14 @@ class CCRMerger2(object):
         negation_context = None
         for cr in app_crs:
             details = rcns_to_details[cr.rule_class_name()]
+            context = AppContext(executable=details.executable, title=details.title)
             if details.function_context is not None:
-                context = FuncContext(function=details.function_context, executable=details.executable, title=details.title)
+                funkcontext = context
+                funkcontext &= FuncContext(function=details.function_context)
+                contexts.append(funkcontext)
             else:
-                context = AppContext(executable=details.executable, title=details.title)
-            contexts.append(context)
+                contexts.append(context)
+
             if negation_context is None:
                 negation_context = ~context
             else:

--- a/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
+++ b/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
@@ -157,11 +157,11 @@ class CCRMerger2(object):
                 contexts.append(funkcontext)
             else:
                 contexts.append(context)
-
-            if negation_context is None:
-                negation_context = ~context
-            else:
-                negation_context &= ~context
+            if details.function_context is None:
+                if negation_context is None:
+                    negation_context = ~context
+                else:
+                    negation_context &= ~context
         contexts.insert(0, negation_context)
         return contexts
 


### PR DESCRIPTION
# Title
Fix FuncContext 

## Description

Changes how Caster creates contexts for CCR/Mapping for applications context. Note not global context.

## Related Issue

Background explanation with the bug #798
An amazing community! A big thank you goes to @mpourmpoulis with that right up and insights with this issue.


## Motivation and Context

This PR fixes FuncContext functions from being evaluated twice, outside of context, and context ignoring the exe/ttitle.

## How Has This Been Tested
This is been tested with app mapping and mergerules(CCR)
- Out of context - FuncContext is not evaluated and fails when set to False or True
- In context - FuncContext is evaluated once and Fails when set to False
- In context - FuncContext is evaluated once and Succeeds when set to True

Test Rule
```
from dragonfly import Function, Repeat, Choice, Dictation, MappingRule, Pause

from castervoice.lib.actions import Key, Text, Mouse
from castervoice.lib.merge.state.actions2 import NullAction

from castervoice.lib.const import CCRType
from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
from castervoice.lib.merge.mergerule import MergeRule
from castervoice.lib.merge.state.short import R


def testfunk():
    print ("Testfunk Evaluated")
    return True # Must return true or false


# Testing for VS code
# I included extra imports above so you can easily switch between MappingRule and MergeRule
class TestFunkRule(MergeRule):
    pronunciation = "Visual Studio Test"

    mapping = {
        "test funk": R(Text("funk")), 
    }
    extras = [
    ]
    defaults = {}


def get_rule():
    return TestFunkRule, RuleDetails(executable="code", function_context = testfunk, ccrtype=CCRType.APP) 

```

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [ ] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
