### PR TITLE
Restructure ccr context creation to fix problems with function contexts without ignoring them from the computation of the negation context

### DIFF
--- a/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
+++ b/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
@@ -1,3 +1,5 @@
+import traceback
+
 from dragonfly.grammar.elements import RuleRef, Alternative, Repetition
 from dragonfly.grammar.rule_compound import CompoundRule
 from dragonfly import FuncContext
@@ -157,7 +159,11 @@ class CCRMerger2(object):
                 if valid:
                     context_evaluations[context] = (result,False)
                 else:
-                    result = old_matches(executable,title,handle)
+                    try : 
+                        result = old_matches(executable,title,handle)
+                    except :
+                        results  = True
+                        traceback.print_exc()
                     context_evaluations[context] = (result,True)
                 return result
             context.matches = matches

--- a/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
+++ b/castervoice/lib/merge/ccrmerging2/ccrmerger2.py
@@ -147,21 +147,32 @@ class CCRMerger2(object):
         :return:
         """
         contexts = []
-        negation_context = None
+        context_evaluations = {} 
+
+        def wrap_context(context):
+            old_matches = context.matches
+            context_evaluations[context] = (False,False)
+            def matches(executable,title,handle):
+                result,valid = context_evaluations[context]
+                if valid:
+                    context_evaluations[context] = (result,False)
+                else:
+                    result = old_matches(executable,title,handle)
+                    context_evaluations[context] = (result,True)
+                return result
+            context.matches = matches
+            return context
+
         for cr in app_crs:
             details = rcns_to_details[cr.rule_class_name()]
             context = AppContext(executable=details.executable, title=details.title)
             if details.function_context is not None:
-                funkcontext = context
-                funkcontext &= FuncContext(function=details.function_context)
-                contexts.append(funkcontext)
-            else:
-                contexts.append(context)
-            if details.function_context is None:
-                if negation_context is None:
-                    negation_context = ~context
-                else:
-                    negation_context &= ~context
+                context &= FuncContext(function=details.function_context)
+            contexts.append(wrap_context(context))
+
+        negation_context = FuncContext(lambda **kw:[x for x in context_evaluations if x.matches(**kw)]==[])
+
+
         contexts.insert(0, negation_context)
         return contexts
 

--- a/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
+++ b/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
@@ -28,7 +28,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
     def _evaluate_context_in_every_permutation(self,contexts,expected_output,data = {}):
         for permutation in permutations(zip(contexts,expected_output)):
             expected = [x[1] for x in permutation]
-            result = [x.matches(**data) for x in permutation]
+            result = [x[0].matches(**data) for x in permutation]
             self.assertEqual(expected,result)
 
     def _evaluate_contexts(self,contexts,data = {}):
@@ -202,7 +202,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
         self._evaluate_context_in_every_permutation(contexts,[True,False,False],
             dict(executable = "vscode", title = "hello",handle=None)
         )
-        nice_value = True
+        
 
 
         # make sure the exception didn't break anything
@@ -233,7 +233,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
 
         alphabet_mr = TestCCRMerger2._create_managed_rule(Alphabet, CCRType.GLOBAL)
         eclipse_app_mr = TestCCRMerger2._create_managed_rule(Navigation, CCRType.APP,function = first_context)
-        vscode_app_mr = TestCCRMerger2._create_managed_rule(VSCodeCcrRule, CCRType.APP,function = second_context)
+        vscode_app_mr = TestCCRMerger2._create_managed_rule(VSCodeCcrRule, CCRType.APP,"vscode",function = second_context)
         result = self.merger.merge_rules([alphabet_mr, eclipse_app_mr, vscode_app_mr], self.sorter)
 
         contexts = [x[1] for x in result.ccr_rules_and_contexts]

--- a/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
+++ b/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
@@ -1,4 +1,6 @@
-from dragonfly.grammar.context import LogicNotContext, Context, LogicAndContext
+from itertools import permutations
+
+from dragonfly.grammar.context import LogicNotContext, Context, LogicAndContext,FuncContext
 from mock import Mock
 from castervoice.lib.context import AppContext
 from castervoice.rules.apps.editor.eclipse_rules.eclipse import EclipseCCR
@@ -20,8 +22,8 @@ from tests.test_util.settings_mocking import SettingsEnabledTestCase
 class TestCCRMerger2(SettingsEnabledTestCase):
 
     @staticmethod
-    def _create_managed_rule(rule_class, ccrtype, executable=None):
-        return ManagedRule(rule_class, RuleDetails(ccrtype=ccrtype, executable=executable))
+    def _create_managed_rule(rule_class, ccrtype, executable=None,function = None):
+        return ManagedRule(rule_class, RuleDetails(ccrtype=ccrtype, executable=executable,function_context = function))
 
     def setUp(self):
         self._set_setting(["miscellaneous", "max_ccr_repetitions"], "4")
@@ -51,7 +53,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
         repeat_rule = result.ccr_rules_and_contexts[0][0]
         context = result.ccr_rules_and_contexts[0][1]
         self.assertEqual("RepeatRule", repeat_rule.__class__.__name__)
-        self.assertIsNone(context)
+        self.assertIsInstance(context, FuncContext)
 
     def test_merge_two(self):
         """
@@ -65,7 +67,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
         repeat_rule = result.ccr_rules_and_contexts[0][0]
         context = result.ccr_rules_and_contexts[0][1]
         self.assertEqual("RepeatRule", repeat_rule.__class__.__name__)
-        self.assertIsNone(context)
+        self.assertIsInstance(context, FuncContext)
 
     def test_merge_two_incompatible(self):
         """
@@ -95,7 +97,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
         self.assertEqual(2, len(result.ccr_rules_and_contexts))
         self.assertEqual("RepeatRule", result.ccr_rules_and_contexts[0][0].__class__.__name__)
         self.assertEqual("RepeatRule", result.ccr_rules_and_contexts[1][0].__class__.__name__)
-        self.assertIsInstance(result.ccr_rules_and_contexts[0][1], LogicNotContext)
+        self.assertIsInstance(result.ccr_rules_and_contexts[0][1], FuncContext)
         self.assertIsInstance(result.ccr_rules_and_contexts[1][1], Context)
 
     def test_words_txt_transformer(self):
@@ -137,7 +139,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
         self.assertEqual("RepeatRule", repeat_rule_1.__class__.__name__)
         self.assertEqual("RepeatRule", repeat_rule_2.__class__.__name__)
         self.assertEqual("RepeatRule", repeat_rule_3.__class__.__name__)
-        self.assertIsInstance(context_1, LogicAndContext)
+        self.assertIsInstance(context_1, FuncContext)
         self.assertIsInstance(context_2, AppContext)
         self.assertIsInstance(context_3, AppContext)
         # TODO: write a similar unit test to check the executables/titles validity of the contexts produced

--- a/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
+++ b/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
@@ -238,7 +238,7 @@ class TestCCRMerger2(SettingsEnabledTestCase):
 
         contexts = [x[1] for x in result.ccr_rules_and_contexts]
         self.assertEqual(3, len(result.ccr_rules_and_contexts))       
-        for p in permutations(contexts):
+        for c in permutations(contexts):
             self._evaluate_contexts(c,dict(executable= "vscode", title = "hello",handle=None))
             self.assertEqual(counter,dict(n = 1,v = 1))
             reset_counter()

--- a/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
+++ b/tests/lib/merge/ccrmerging2/test_CCRMerger2.py
@@ -25,6 +25,13 @@ class TestCCRMerger2(SettingsEnabledTestCase):
     def _create_managed_rule(rule_class, ccrtype, executable=None,function = None):
         return ManagedRule(rule_class, RuleDetails(ccrtype=ccrtype, executable=executable,function_context = function))
 
+    def _evaluate_context_in_every_permutation(self,contexts,expected_output,data = {}):
+        for permutation in permutations(zip(contexts,expected_output)):
+            expected = [x[1] for x in permutation]
+            result = [x.matches(**data) for x in permutation]
+            self.assertEqual(expected,result)
+
+
     def setUp(self):
         self._set_setting(["miscellaneous", "max_ccr_repetitions"], "4")
         self.selfmodrule_configurer = Mock()
@@ -142,4 +149,17 @@ class TestCCRMerger2(SettingsEnabledTestCase):
         self.assertIsInstance(context_1, FuncContext)
         self.assertIsInstance(context_2, AppContext)
         self.assertIsInstance(context_3, AppContext)
+        
+        self._evaluate_context_in_every_permutation([context_1, context_2, context_3],
+            [True,False,False],
+            dict(executable = "sublime_text", title = "hello",handle=None)
+        )
+        self._evaluate_context_in_every_permutation([context_1, context_2, context_3],
+            [False,True,False],
+            dict(executable = "eclipse", title = "hello",handle=None)
+        )
+        self._evaluate_context_in_every_permutation([context_1, context_2, context_3],
+            [False,False,True],
+            dict(executable = "vscode", title = "hello",handle=None)
+        )
         # TODO: write a similar unit test to check the executables/titles validity of the contexts produced

--- a/tests/testrunner.py
+++ b/tests/testrunner.py
@@ -2,6 +2,9 @@ import os
 import sys
 import unittest
 
+if os.path.dirname(os.path.dirname(os.path.abspath(__file__))) not in sys.path:
+	sys.path.insert(0,os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from dragonfly import get_engine
 
 from castervoice.lib.ctrl.mgr.errors.guidance_rejection import GuidanceRejectionException


### PR DESCRIPTION
# Title

<!-- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.-->

## Description

This is essentially part two of #820 that's tried to address #798 And took care of most of the work needed but left a couple of details open, like excluding function contexts from the computation of the negation context, In order to avoid an edge case that could leave the user without global commands. This problem is now taken care off without sometimes leaving two merged CCR's active

This is achieved by tweaking the matches function of context created to cache It's result So it can be reused precisely one more time! as a consequence, the context gets evaluated Only once even though it is used both for its own grammar as well as for negation context. Furthermore, the implementation does not depend on the order in which the contexts are being processed
<!-- Describe your changes in detail -->

## Related Issue

<!-- Please reference any related issues here -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.
