### PR TITLE
Sanitize BringMe/Alias specs

### DIFF
--- a/castervoice/rules/ccr/recording_rules/alias/base_alias.py
+++ b/castervoice/rules/ccr/recording_rules/alias/base_alias.py
@@ -1,3 +1,5 @@
+import re
+
 from dragonfly import Function
 
 from castervoice.lib import settings, context
@@ -53,9 +55,9 @@ class BaseAliasRule(BaseSelfModifyingRule):
         :return:
         """
         text = BaseAliasRule._read_highlighted(10)
-        spec = str(spec)
         if text is not None:
             if spec:
+                spec = re.sub(r'[^A-Za-z\'\s]+', '', str(spec)).lower() # Sanitize free dictation for spec, words and apostrophes only.
                 self._refresh(spec, str(text))
             else:
                 h_launch.launch(settings.QTYPE_INSTRUCTIONS, data="Enter_spec_for_command|")

--- a/castervoice/rules/ccr/recording_rules/bringme.py
+++ b/castervoice/rules/ccr/recording_rules/bringme.py
@@ -4,6 +4,7 @@ import shlex
 import threading
 import time
 from subprocess import Popen
+import re
 
 import six
 if six.PY2:
@@ -59,7 +60,6 @@ class BringRule(BaseSelfModifyingRule):
         """
         This _deserialize creates mapping which uses the user-made extras.
         """
-
         self._initialize()
 
         self._smr_mapping = {
@@ -85,7 +85,8 @@ class BringRule(BaseSelfModifyingRule):
                 "terminal": "terminal",
                 "explorer": "explorer",
             }),
-            Dictation("key"),
+            # Sanitize free dictation for spec, words and apostrophes only.
+            Dictation("key").apply(lambda key: re.sub(r'[^A-Za-z\'\s]+', '', key).lower()),
         ]
         self._smr_extras.extend(self._rebuild_items())
         self._smr_defaults = {"app": None}


### PR DESCRIPTION
## Description

Some sort of basic sanity check was needed for Alias/BringMe. This PR implement stripping out all symbols except for alphabet and apostrophes from user created Alias/BringMe specs.

## Related Issue

Basic sanity check for alias #694

## Motivation and Context

Speech recognition engines don't expect special or numerical inspects. With the exception being of apostrophes. DNS does have some exceptions but this handles it for all engines supported by dragonfly.

## How Has This Been Tested

Tested on DNS/WSR/Kaldi

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
