### PR TITLE
BugFix: `Again` grammar #833 and #834

### DIFF
--- a/castervoice/rules/ccr/recording_rules/again.py
+++ b/castervoice/rules/ccr/recording_rules/again.py
@@ -26,13 +26,13 @@ class Again(MappingRule):
 
     @staticmethod
     def _create_asynchronous(n):
+        last_utterance_index = 2
         if len(_history) == 0:
             return
 
-        last_utterance_index = 2
-        if get_current_engine().name in ["sapi5shared", "sapi5", "sapi5inproc"]:  # ContextStack adds the word to history before executing it
+        # ContextStack adds the word to history before executing it for WSR 
+        if get_current_engine().name in ["sapi5shared", "sapi5", "sapi5inproc"]:  
             if len(_history) == 1: return
-            last_utterance_index = 2
 
         # Calculatees last utterance from recognition history and creates list of str for Dragonfly Playback
         utterance = map(str, (_history[len(_history) - last_utterance_index]))

--- a/castervoice/rules/ccr/recording_rules/again.py
+++ b/castervoice/rules/ccr/recording_rules/again.py
@@ -34,9 +34,9 @@ class Again(MappingRule):
             if len(_history) == 1: return
             last_utterance_index = 2
 
-        utterance = [
-            str(x) for x in " ".join(_history[len(_history) - last_utterance_index]).split()
-        ]
+        # Calculatees last utterance from recognition history and creates list of str for Dragonfly Playback
+        utterance = map(str, (_history[len(_history) - last_utterance_index]))
+
         if utterance[0] == "again": return
         forward = [L(S(["cancel"], lambda: Again._repeat(utterance)))]
         AsynchronousAction(

--- a/castervoice/rules/ccr/recording_rules/again.py
+++ b/castervoice/rules/ccr/recording_rules/again.py
@@ -35,7 +35,7 @@ class Again(MappingRule):
             if len(_history) == 1: return
 
         # Calculatees last utterance from recognition history and creates list of str for Dragonfly Playback
-        utterance = map(str, (_history[len(_history) - last_utterance_index]))
+        utterance = list(map(str, _history[len(_history) - last_utterance_index]))
 
         if utterance[0] == "again": return
         forward = [L(S(["cancel"], lambda: Again._repeat(utterance)))]

--- a/castervoice/rules/ccr/recording_rules/again.py
+++ b/castervoice/rules/ccr/recording_rules/again.py
@@ -1,14 +1,14 @@
-from dragonfly import Function, Playback, RecognitionHistory, MappingRule, get_current_engine
+from dragonfly import Function, Playback, MappingRule, get_current_engine, ShortIntegerRef
 
 from castervoice.lib import settings
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.actions import AsynchronousAction
 from castervoice.lib.merge.state.short import R, L, S
 from castervoice.lib.util import recognition_history
 
 _history = recognition_history.get_and_register_history(10)
 
+#TODO: Investigate why Caster's abstraction of dragonflys `ShortIntegerRef` Via `IntegerRefST` causes recognition errors in this grammar.
 
 class Again(MappingRule):
 
@@ -16,13 +16,13 @@ class Again(MappingRule):
         "again (<n> [(times|time)] | do)":
             R(Function(lambda n: Again._create_asynchronous(n)), show=False),  # pylint: disable=E0602
     }
-    extras = [IntegerRefST("n", 1, 50)]
+    extras = [ShortIntegerRef("n", 1, 50)]
     defaults = {"n": 1}
 
     @staticmethod
     def _repeat(utterance):
         Playback([(utterance, 0.0)]).execute()
-        return False
+        return False 
 
     @staticmethod
     def _create_asynchronous(n):


### PR DESCRIPTION
## Description
The following PR fixes two bugs in the `Again` grammar.

1. Replaced Caster's `IntegerRefST` is an abstraction for Dragonfly `ShortIntegerRef`
For some reason Dragonfly `ShortIntegerRef` is much more accurate than casters abstraction via `IntegerRefST`
**Note**: This fixes the grammar. However if there is an issue with the underlying abstraction of `IntegerRefST` this needs to be evaluated in a new issue.

2. Fixed 'again do' speech recognition history conversion for dragonfly playback.
The errors occur primarily because the during the conversion to a list of strings for playback it assumes one word per string. DNS recognition history for built-in commands and proper pronouns can have multiple words/symbols as one string. The assumption in this new code is that the reported history by the speech engine backend is always correct for the dragonfly playback function.

## Related Issue

#833 #834

## How Has This Been Tested

Please reference the respective issues for testing methodology as they were used in creating this PR.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
