### PR TITLE
Fix Legion for Python 3

### DIFF
--- a/castervoice/asynch/mouse/legion.py
+++ b/castervoice/asynch/mouse/legion.py
@@ -179,8 +179,7 @@ class LegionScanner:
                 self.tirg_dll = cdll.LoadLibrary(str(Path(settings.SETTINGS["paths"]["DLL_PATH"]).joinpath("tirg-32.dll")).encode(
                 sys.getfilesystemencoding()))
             else:
-                self.tirg_dll = cdll.LoadLibrary(str(Path(settings.SETTINGS["paths"]["DLL_PATH"]).joinpath("tirg-64.dll")).encode(
-                sys.getfilesystemencoding()))
+                self.tirg_dll = cdll.LoadLibrary(str(Path(settings.SETTINGS["paths"]["DLL_PATH"]).joinpath("tirg-64.dll")))
         except Exception as e:
             print("Legion loading failed with '%s'" % str(e))
         self.tirg_dll.getTextBBoxesFromFile.argtypes = [c_char_p, c_int, c_int]
@@ -192,7 +191,7 @@ class LegionScanner:
         bbstring = self.tirg_dll.getTextBBoxesFromBytes(img.tobytes(), img.size[0],
                                                         img.size[1])
         # clean the results in case any garbage letters come through
-        result = re.sub("[^0-9,]", "", bbstring)
+        result = re.sub("[^0-9,]", "", bbstring.decode("utf-8"))
         return result
 
     def scan(self, bbox=None, rough=True):

--- a/castervoice/asynch/mouse/legion.py
+++ b/castervoice/asynch/mouse/legion.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import threading
+import locale
 from ctypes import *
 from dragonfly import monitors
 
@@ -191,7 +192,7 @@ class LegionScanner:
         bbstring = self.tirg_dll.getTextBBoxesFromBytes(img.tobytes(), img.size[0],
                                                         img.size[1])
         # clean the results in case any garbage letters come through
-        result = re.sub("[^0-9,]", "", bbstring.decode(sys.getfilesystemencoding()))
+        result = re.sub("[^0-9,]", "", bbstring.decode(locale.getpreferredencoding()))
         return result
 
     def scan(self, bbox=None, rough=True):

--- a/castervoice/asynch/mouse/legion.py
+++ b/castervoice/asynch/mouse/legion.py
@@ -191,7 +191,7 @@ class LegionScanner:
         bbstring = self.tirg_dll.getTextBBoxesFromBytes(img.tobytes(), img.size[0],
                                                         img.size[1])
         # clean the results in case any garbage letters come through
-        result = re.sub("[^0-9,]", "", bbstring.decode("utf-8"))
+        result = re.sub("[^0-9,]", "", bbstring.decode(sys.getfilesystemencoding()))
         return result
 
     def scan(self, bbox=None, rough=True):

--- a/castervoice/asynch/mouse/legion.py
+++ b/castervoice/asynch/mouse/legion.py
@@ -237,10 +237,6 @@ def main(argv):
     dimensions = None
     auto_quit = False
 
-    error_code = windll.shcore.SetProcessDpiAwareness(2)  #enable 1-1 pixel mapping
-    if error_code == -2147024891:
-        raise OSError("Failed to set app awareness")
-
     try:
         opts, args = getopt.getopt(argv, "ht:a:d:m:",
                                    ["tirg=", "dimensions=", "autoquit="])

--- a/castervoice/asynch/mouse/legion.py
+++ b/castervoice/asynch/mouse/legion.py
@@ -114,7 +114,7 @@ class LegionGrid(TkTransparent):
         # Helper class for splitting larger rectangles to smaller ones.
         for rect in rectangles_to_split:
             width = rect.x2 - rect.x1
-            pieces = width/self.max_rectangle_width
+            pieces = width//self.max_rectangle_width
             new_width = width/pieces
             for i in range(0, pieces):
                 r = Rectangle()

--- a/castervoice/asynch/mouse/legion.py
+++ b/castervoice/asynch/mouse/legion.py
@@ -177,8 +177,7 @@ class LegionScanner:
         import struct
         try:
             if struct.calcsize("P") * 8 == 32:
-                self.tirg_dll = cdll.LoadLibrary(str(Path(settings.SETTINGS["paths"]["DLL_PATH"]).joinpath("tirg-32.dll")).encode(
-                sys.getfilesystemencoding()))
+                self.tirg_dll = cdll.LoadLibrary(str(Path(settings.SETTINGS["paths"]["DLL_PATH"]).joinpath("tirg-32.dll")))
             else:
                 self.tirg_dll = cdll.LoadLibrary(str(Path(settings.SETTINGS["paths"]["DLL_PATH"]).joinpath("tirg-64.dll")))
         except Exception as e:

--- a/castervoice/lib/gdi.py
+++ b/castervoice/lib/gdi.py
@@ -44,13 +44,15 @@ def grab_screen(bbox=None):
     """
 
     def cleanup():
-        if bitmap:
+        if 'bitmap' in locals() or 'bitmap' in globals():
             DeleteObject(bitmap)
-        DeleteDC(screen_copy)
-        DeleteDC(screen)
+        if 'screen_copy' in locals() or 'screen_copy' in globals():
+            DeleteDC(screen_copy)
+        if 'screen' in locals() or 'screen' in globals():
+            DeleteDC(screen)
 
     try:
-        screen = CreateDC(c_char_p('DISPLAY'), NULL, NULL, NULL)
+        screen = CreateDC(c_char_p('DISPLAY'.encode('utf-8')), NULL, NULL, NULL)
         screen_copy = CreateCompatibleDC(screen)
 
         if bbox:
@@ -79,7 +81,7 @@ def grab_screen(bbox=None):
 
         bitmap_header = pack('LHHHH', calcsize('LHHHH'), width, height, 1, 24)
         bitmap_buffer = c_buffer(bitmap_header)
-        bitmap_bits = c_buffer(' ' *(height*((width*3 + 3) & -4)))
+        bitmap_bits = c_buffer(b' ' *(height*((width*3 + 3) & -4)))
         got_bits = GetDIBits(screen_copy, bitmap, 0, height, bitmap_bits, bitmap_buffer,
                              0)
         if got_bits == NULL or got_bits == ERROR_INVALID_PARAMETER:

--- a/castervoice/rules/apps/mouse_grids/gridlegion.py
+++ b/castervoice/rules/apps/mouse_grids/gridlegion.py
@@ -66,7 +66,7 @@ class LegionGridRule(MappingRule):
             R(Function(send_input)),
         "refresh":
             R(Function(navigation.mouse_alternates, mode="legion")),
-        SymbolSpecs.CANCEL:
+        SymbolSpecs.CANCEL + " {weight=2}":
             R(Function(kill)),
         "<n1> (select | light) <n2>":
             R(Function(drag_highlight)),


### PR DESCRIPTION
# Fix Legion for Python 3

## Description

Most of the changes relate to clarifying encoding as is required Python 3.

The exception is in gdi.py `cleanup()`, where Python 3 won't let you make reference to an object which doesn't necessarily exist. In that bit, you have to refer to the potential object name as a string.

It also adds some weight to the legion clicker so that it works in Kaldi.

## Related Issue

#838

## Motivation and Context

Python 3 port.

## How Has This Been Tested

On a Windows VirtualBox. Tested using both Python 3.8 and 2.7. Tested only using Kaldi. I just tried saying "legion" and "legion 2" and both worked.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.