### PR TITLE
Document Kaldi installation on MacOS

### DIFF
--- a/docs/readthedocs/Installation/Kaldi.md
+++ b/docs/readthedocs/Installation/Kaldi.md
@@ -35,6 +35,25 @@ Make sure to select `Add python to path`. This can be done manually by searching
 2. Delete `%USERPROFILE%\Documents\Caster`
 3. Repeat Steps `1. - 5.` within the Caster install section
 
+## MacOS
+
+### Requirements
+
+* PiP ([Installing with get-pip.py](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py))
+
+### Installation
+
+Open up a terminal and follow these steps:
+```
+git clone https://github.com/dictation-toolbox/Caster
+cd Caster
+python -m pip install -r requirements-mac-linux.txt
+python -m pip install "dragonfly2[kaldi]"
+curl -LO https://github.com/daanzu/kaldi-active-grammar/releases/download/v1.4.0/kaldi_model_daanzu_20200328_1ep-mediumlm.zip
+unzip kaldi_model_daanzu_20200328_1ep-mediumlm.zip
+python -m dragonfly load _*.py --engine kaldi --no-recobs-messages
+```
+
 ------
 
    **Troubleshooting Kaldi** 


### PR DESCRIPTION
# Document Kaldi installation on MacOS

<!-- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.-->

## Description

No installation instructions for MacOS using Kaldi are supported in the documentation. This should give a first basis as a reference for future documentation improvements. It was inspired by https://github.com/kmdouglass/homelab/blob/master/speech-recognition/toolchains/caster-kaldi/Dockerfile .

## Related Issue

--

## Motivation and Context

Document installation steps required to install Caster with Kaldi on MacOS.

## How Has This Been Tested

Tested with `mkdocs`.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] I have updated the documentation accordingly.


## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
