### PR TITLE
Add new shortcuts for Visual Studio

### DIFF
--- a/castervoice/rules/apps/editor/visualstudio.py
+++ b/castervoice/rules/apps/editor/visualstudio.py
@@ -59,7 +59,7 @@ class VisualStudioRule(MappingRule):
             R(Key("f11")),
         "step out [of]":
             R(Key("s-f11")),
-        "resume":
+        "(resume | go debug)":
             R(Key("f5")),
         "run tests":
             R(Key("c-r, t")),
@@ -79,6 +79,14 @@ class VisualStudioRule(MappingRule):
             R(Key("a-m, g")),
         "[add] [new] linked work item":
             R(Key("sa-l")),
+        "go back":
+            R(Key("c--")),
+        "go forward":
+            R(Key("cs--")),
+        "go to definition":
+            R(Key("f12")),
+        "show refs":
+            R(Key("a-2")),	
     }
     extras = [
         Dictation("text"),

--- a/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
@@ -617,18 +617,20 @@ Same Commands as [Git Bash](#git-bash)
 
 | Command                            | Command                      | Command                             |
 | :--------------------------------- | :--------------------------- | :---------------------------------- |
-| `(list / show) documents`          | `collapse to definitions`    | `run all tests`                     |
-| `(set / toggle) bookmark`          | `comment block`              | `run tests`                         |
-| `(show / view) history`            | `comment line`               | `solution explorer`                 |
-| `(un / on) comment block`          | `compare (files / versions)` | `source control explorer`           |
-| `(un / on) comment line`           | `get latest [version]`       | `step into`                         |
-| `[add] [new] linked work item`     | `go to line`                 | `step out [of]`                     |
-| `[focus] document (window / pane)` | `next bookmark`              | `step over [<n>]`                   |
-| `[open] [go to] work item`         | `next tab [<n>]`             | `team explorer`                     |
-| `[toggle] break point`             | `prior bookmark`             | `toggle [section] outlining`        |
-| `[toggle] full screen`             | `prior tab [<n>]`            | `toggle all outlining`              |
-| `build solution`                   | `quick launch`               | `undo (checkout / pending changes)` |
-| `close tab [<n>]`                  | `resume`                     |                                     |
+| `(list / show) documents`          | `comment line`               | `resume`                            |
+| `(set / toggle) bookmark`          | `compare (files / versions)` | `run all tests`                     |
+| `(show / view) history`            | `get latest [version]`       | `run tests`                         |
+| `(un / on) comment block`          | `go back`                    | `show refs`                         |
+| `(un / on) comment line`           | `go forward`                 | `solution explorer`                 |
+| `[add] [new] linked work item`     | `go to debug`                | `source control explorer`           |
+| `[focus] document (window / pane)` | `go to definition`           | `step into`                         |
+| `[open] [go to] work item`         | `go to line`                 | `step out [of]`                     |
+| `[toggle] break point`             | `next bookmark`              | `step over [<n>]`                   |
+| `[toggle] full screen`             | `next tab [<n>]`             | `team explorer`                     |
+| `build solution`                   | `prior bookmark`             | `toggle [section] outlining`        |
+| `close tab [<n>] `                 | `prior tab [<n>]`            | `toggle all outlining`              |
+| `collapse to definitions`          | `quick launch`               | `undo (checkout / pending changes)` |
+| `comment block`                    |                              |                                     |
 
 # Visual Studio Code
 

--- a/docs/readthedocs/Caster_Commands/CCR_languages_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/CCR_languages_Quick_Reference.md
@@ -250,6 +250,7 @@ Classic Install Location: `castervoice\rules\ccr` in Caster source code.
 | link                               | `<link >`                      | video close                    | `</video>`                                                      |
 | list element / DL                  | `<dl>`                         | small                          | `<small></small>`                                               |
 | time                               | `<time></time>`                |                                |                                                                 |
+
 # CSS
 
 The CSS commands are designed just like human language. Basically you can write CSS exactly as you read it.


### PR DESCRIPTION
# Add new shortcuts for Visual Studio

## Description

Add new shortcuts for Visual Studio

## Related Issue


## Motivation and Context

Visual Studio was lacking commands for a few basic features, specifically Go Back, Go Forward, Go to Definition, and Show References which I shortened to Show Refs. 

`resume` was an odd name for a command that begins a debug session, although it is the same keypress as a continue action when debug hits a breakpoint, so I also added an additional phrase `go to debug` to the f5 keypress.

## How Has This Been Tested

These changes were tested in use against Visual Studio Professional 2019 and are voice commands for existing keyboard shortcuts. I believe these are all keyboard shortcuts that I used on previous versions of Visual Studio but no longer have them installed to verify.

I see in the checklist a reference to writing actual tests against the code, but I didn't see the tests and the Contributing document does not reference how to create such tests, and I didn't see any documentation for tests in the code, so I did not run or contribute to any automated testing.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [x] New documentation is clear and complete.
- [x] Code is clear and readable.
