### PR TITLE
Jetbrains Commands Updates

### DIFF
--- a/castervoice/rules/apps/editor/jetbrains.py
+++ b/castervoice/rules/apps/editor/jetbrains.py
@@ -28,7 +28,7 @@ class JetbrainsRule(MappingRule):
     mapping = {
         "quick fix": R(Key("a-enter")),
         "(duplicate|duple) %s" % DOWN: R(Key("c-d")),
-        "auto complete": R(Key("cs-a")),
+        "find action": R(Key("cs-a")),
         "format [code]": R(Key("ca-l")),
         "show doc": R(Key("c-q")),
         "find class": R(Key("c-n")),
@@ -42,9 +42,11 @@ class JetbrainsRule(MappingRule):
         "select ex down" : R(Key("cs-w")),
         "find file": R(Key("shift, shift")),
         "find": R(Key("c-f")),
+        "find next": R(Key("f3")),
+        "find prior": R(Key("f3")),
         "find %s [match] [<n>]" % FORWARD: R(Key("enter")) * Repeat(extra="n"),
         "find %s [match] [<n>]" % BACK: R(Key("s-enter")) * Repeat(extra="n"),
-        "replace": R(Key("c-r")),
+        "replace [here]": R(Key("c-r")),
         "find [in] (all|files)": R(Key("cs-f")),
         "replace [in] (all|files)": R(Key("cs-r")),
         "go [to line] [<n>]": R(Key("c-g/%s" % DELAY) + Text("%(n)s") + Key("enter")),
@@ -52,12 +54,17 @@ class JetbrainsRule(MappingRule):
         "override %s" % method: R(Key("c-o")),
         "run config": R(Key("as-f10")),
         "[find] (usage|usages)": R(Key("a-f7")),
+        "show (usage|usages)": R(Key("ca-f7")),
+        "[find] (usage|usages) in file": R(Key("c-f7")),
         "[go to] (source|declaration)": R(Key("c-b")),
+        "[go to] implementation": R(Key("ca-b")),
         "(skraken|smart kraken)": R(Key("cs-space")),
         "go %s [<n>]" % FORWARD: R(Key("ca-right")) * Repeat(extra="n"),
         "go %s [<n>]" % BACK: R(Key("ca-left")) * Repeat(extra="n"),
         "%s %s [<n>]" % (method, FORWARD): R(Key("a-down")) * Repeat(extra="n"),
         "%s %s [<n>]" % (method, BACK): R(Key("a-up")) * Repeat(extra="n"),
+        "go block start": R(Key("c-[")),
+        "go block end": R(Key("c-]")),
         "(%s error|error %s)" % (FORWARD, RIGHT): R(Key("f2")) * Repeat(extra="n"),
         "(%s error|error %s)" % (BACK, LEFT): R(Key("s-f2")) * Repeat(extra="n"),
         "[organize|optimize] imports": R(Key("ca-o")) * Repeat(extra="n"),
@@ -71,6 +78,10 @@ class JetbrainsRule(MappingRule):
         "debug": R(Key("s-f9")),
         "redo [<n>]": R(Key("cs-z")) * Repeat(extra="n"),
         "[show] settings": R(Key("ca-s")),
+        "collapse": R(Key("c--")),
+        "uncollapse": R(Key("c-+")),
+        "collapse all": R(Key("cs--")),
+        "uncollapse all": R(Key("cs-+")),
 
         # only works if you disable tabs.
         "close pane [<n>]|pane close [<n>]": R(Key("c-f4/%s" % DELAY)) * Repeat(extra="n"),
@@ -85,9 +96,18 @@ class JetbrainsRule(MappingRule):
         "%s constant" % extract: R(Key("ca-c")) * Repeat(extra="n"),
         "%s (param|parameter)" % extract: R(Key("ca-p")) * Repeat(extra="n"),
 
+        # debugging
+        "step over": R(Key("f8")),
+        "step into": R(Key("f7")),
+        "smart step over": R(Key("s-f7")),
+        "step out": R(Key("s-f8")),
+        "toggle breakpoint": R(Key("c-f8")),
+        "view breakpoints": R(Key("cs-f8,cs-f8")),
+        "continue": R(Key("f9")),
+
         # window navigation
         "focus editor": R(Key("escape")),
-        "go [to] project": R(Key("a-1")),
+        "go tool <n>": R(Key("a-%(n)s")),
         "[toggle] (term|terminal)": R(Key("a-f12")),
 
         # must be bound manually below this point
@@ -116,5 +136,5 @@ class JetbrainsRule(MappingRule):
 
 def get_rule():
     details = RuleDetails(name="jet brains",
-                          executable=["idea", "idea64", "studio64", "pycharm", "rider64"])
+                          executable=["idea", "idea64", "studio64", "pycharm", "rider64", "webstorm", "webstorm64"])
     return JetbrainsRule, details

--- a/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
@@ -369,7 +369,10 @@ Same Commands as [Git Bash](#git-bash)
 | `emphasize`     | `insert image`   | `mention`     |
 | `<size> header` | `strikethrough`  | `latex`       |
 
-# Jetbrains
+# Jetbrains 
+
+It is worth noting that JetBrains commands may vary differently on Mac, versus Windows/Linux. 
+These commands are for Windows/Linux and creating a separate command ruleset for JetBrains on Mac is probably necessary.
 
 | Command                               | Command                        | Command                          |
 | :------------------------------------ | :----------------------------- | :------------------------------- |

--- a/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
@@ -371,26 +371,33 @@ Same Commands as [Git Bash](#git-bash)
 
 # Jetbrains
 
-| Command                          | Command                    | Command                     |
-| :------------------------------- | :------------------------- | :-------------------------- |
-| `Jen method`                     | `find in current`          | `search [everywhere]`       |
-| `auto complete`                  | `format code`              | `find symbol`               |
-| `auto file`                      | `format class`             | `[find] usage`              |
-| `build`                          | `go to line`               | `select ex`                 |
-| `build and run`                  | `jump to source`           | `select ex down`            |
-| `comment [line]`                 | `next tab`                 | `show doc`                  |
-| `delete line`                    | `prior tab`                | `show param`                |
-| `duplicate`                      | `quick fix`                | `uncomment line`            |
-| `expand [selection] [<n>]`       | `smart auto complete`      | `quick fix`                 |
-| `split right`                    | `pane left`                | `pane right`                |
-| `split down`                     | `pane down`                | `pane up`                   |
-| `split`                          | `last tab`                 | `second last tab`           |
-| `go [to] editor`                 | `go [to] project explorer` | `toggle terminal`           |
-| `new file`                       | `method forward`           | `method back`               |
-| `[move] line up`                 | `kill forward`             | `extract method`            |
-| `[move] line down`               | `kill back`                | `extract constant`          |
-| `extract param`                  | `kill`                     | `override method`           |
-| `auto indent`                    |                            |                             |
+| Command                               | Command                        | Command                          |
+| :------------------------------------ | :----------------------------- | :------------------------------- |
+| `auto indent`                         | `build`                        | `build and run`                  |
+| `close pane [<n>] / pane close [<n>]` | `close tab [<n>]`              | `collapse`                       |
+| `collapse all`                        | `(comment / rem) [line]`       | `continue`                       |
+| `debug`                               | `(duplicate / duple)`          | `(%s error / error %s)`          |
+| `expand [selection] [<n>]`            | `extract (param / parameter)`  | `extract [variable|var]`         |
+| `extract constant`                    | `extract field`                | `file rename / rename file`      |
+| `find`                                | `find %s [match] [<n>]`        | `find [in] (all / files)`        |
+| `find action`                         | `find class`                   | `find file`                      |
+| `find next`                           | `find prior`                   | `[find] (usage / usages)`        |
+| `[find] (usage / usages) in file`     | `focus editor`                 | `format [code]`                  |
+| `go %s [<n>]`                         | `go [to line] [<n>]`           | `go block end`                   |
+| `go block start`                      | `go tool <n>`                  | `[go to] (source / declaration)` |
+| `[go to] implementation`              | `implement (method / methods)` | `inline`                         |
+| `(kill / delete) %s`                  | `method %s [<n>]`              | `[move] line %s [<n>]`           |
+| `(organize / optimize) imports`       | `override method`              | `pane %s [<n>]`                  |
+| `(pane %s / %s pane) [<n>]`           | `(pull / extract)`             | `quick fix`                      |
+| `redo [<n>]`                          | `refactor`                     | `rename`                         |
+| `replace [here]`                      | `replace [in] (all / files)`   | `run config`                     |
+| `run config`                          | `select ex`                    | `select ex down`                 |
+| `show (usage / usages)`               | `show doc`                     | `[show] settings`                |
+| `shrink [selection] [<n>]`            | `(skraken / smart kraken)`     | `smart step over`                |
+| `split [pane] %s`                     | `step into`                    | `step out`                       |
+| `step over`                           | `%s tab [<n>] / tab %s [<n>]`  | `toggle breakpoint`              |
+| `[toggle] (term / terminal)`          | `uncollapse`                   | `uncollapse all`                 |
+| `(uncomment / unrem) [line]`          | `view breakpoints`             |                                  |
 | GIT Commands (embedded terminal) |                            |                             |
 | `(get push / push)`              | `fetch`                    | `search recursive filetype` |
 | `(undo changes / reset hard)`    | `gooey blame`              | `stash`                     |


### PR DESCRIPTION
Jetbrains Commands Updates

## Description

The documentation for the Jetbrains rules was clearly out of date with the code. I made code changes and then updated the documentation to match the code, so the documentation changes do look like I may have made more changes than I actually did. 

Of note, I renamed the commands:
"auto complete" to "find action". This shortcut previously coded opens a find dialog to find actions in the code. It does nothing even close to resembling auto complete.

"replace" to "replace [here]" - replace is currently getting overridden by the core replace and therefore broken. As referenced in gitter chat, this could also be resolved with a weighting workaround, but I figured adding an extra word of specificity would allow this to fallback to replace if kaldi does implement app specificity overriding global at a later time. Works well in practice.

"go [to] project" to "go tool <n>". In Jetbrains the first 9 tools have a number corresponding to them and work with this shortcut. The keyboard shortcut happening for "go [to] project"  has never been go to project, as far as I can tell, after looking at shortcut mappings for multiple jetbrains projects. It appears to me that this shortcut has always been toggling the different tool panes. 

I also added support for Webstorm and 18 entirely new commands which should be obvious in the diff.


## Motivation and Context

Compared to other IDEs there were significant missing commands. I use WebStorm every day.

## How Has This Been Tested

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested each command that was applicable, on WebStorm 2020.2. I did not edit commands which do not work in WebStorm, although I did notice some in the IntelliJ shortcut reference. I do not have a license for IntelliJ IDEA.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [x] New documentation is clear and complete.
- [x] Code is clear and readable.
