### PR TITLE
Add hold and release

### DIFF
--- a/castervoice/rules/ccr/voice_dev_commands_rules/voice_dev_commands.py
+++ b/castervoice/rules/ccr/voice_dev_commands_rules/voice_dev_commands.py
@@ -16,7 +16,7 @@ from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
-new_modifier_choice_object = copy.deepcopy(Navigation.modifier_choice_object)
+new_pre_modifier_choice_object = copy.deepcopy(Navigation.pre_modifier_choice_object)
 
 def split_dictation(text):
     if text:
@@ -88,8 +88,8 @@ class VoiceDevCommands(MergeRule):
 
         # Dragonfly Snippets
         # this first command is probably the most useful one
-        "dev key [<modifier>] <combined_button_dictionary>": 
-            R(Text('Key("%(modifier)s%(combined_button_dictionary)s")'),
+        "dev key [<pre_modifier>] <combined_button_dictionary>": 
+            R(Text('Key("%(pre_modifier)s%(combined_button_dictionary)s")'),
             rdescript="DragonflyDev: Snippet for creating a full Key action"),
         "dev key":
             R(Text('Key("")') + Key("left:2"), rdescript="DragonflyDev: Snippet for Key Action"),
@@ -198,7 +198,7 @@ class VoiceDevCommands(MergeRule):
     }
 
     extras = [
-        new_modifier_choice_object,
+        new_pre_modifier_choice_object,
         Choice("combined_button_dictionary", Navigation.combined_button_dictionary),
         Dictation("text"),
         Dictation("dict"),

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -176,21 +176,18 @@ class Navigation(MergeRule):
             R(Key("cs-left:%(nnavi500)s")),
         "flitch [<nnavi500>]":
             R(Key("cs-right:%(nnavi500)s")),
-        "<modifier> <button_dictionary_500> [<nnavi500>]":
-            R(Key("%(modifier)s%(button_dictionary_500)s")*Repeat(extra='nnavi500'),
-              rdescript="press modifier keys plus buttons from button_dictionary_500"),
-        "<modifier> <button_dictionary_10> [<nnavi10>]":
-            R(Key("%(modifier)s%(button_dictionary_10)s")*Repeat(extra='nnavi10'),
-              rdescript="press modifier keys plus buttons from button_dictionary_10"),
-        "<modifier> <button_dictionary_1>":
-              R(Key("%(modifier)s%(button_dictionary_1)s"),
-              rdescript="press modifiers plus buttons from button_dictionary_1, non-repeatable"),
-
-        # "key stroke [<modifier>] <combined_button_dictionary>":
-        #     R(Text('Key("%(modifier)s%(combined_button_dictionary)s")')),
-
-        # "key stroke [<modifier>] <combined_button_dictionary>":
-        #     R(Text('Key("%(modifier)s%(combined_button_dictionary)s")')),
+        "<pre_modifier> <button_dictionary_500> [<nnavi500>]":
+            R(Key("%(pre_modifier)s%(button_dictionary_500)s")*Repeat(extra='nnavi500'),
+              rdescript="press pre_modifier keys plus buttons from button_dictionary_500"),
+        "<pre_modifier> <button_dictionary_10> [<nnavi10>]":
+            R(Key("%(pre_modifier)s%(button_dictionary_10)s")*Repeat(extra='nnavi10'),
+              rdescript="press pre_modifier keys plus buttons from button_dictionary_10"),
+        "<pre_modifier> <button_dictionary_1>":
+              R(Key("%(pre_modifier)s%(button_dictionary_1)s"),
+              rdescript="press pre_modifiers plus buttons from button_dictionary_1, non-repeatable"),
+        "<post_modifier> <button_dictionary_1>":
+              R(Key("%(button_dictionary_1)s:%(post_modifier)s"),
+              rdescript="press buttons from button_dictionary_1 with post modifier, non-repeatable"),
     }
     tell_commands_dict = {"dock": ";", "doc": ";", "sink": "", "com": ",", "deck": ":"}
     tell_commands_dict.update(_tpd)
@@ -240,13 +237,20 @@ class Navigation(MergeRule):
         "six": "6",
         "seven": "7",
         "eight": "8",
-        "nine": "9"
+        "nine": "9",
+        "[lease] alt": "alt",
+        "ross alt": "ralt",
+        "[lease] (control | fly)": "control",
+        "ross (control | fly)": "rcontrol",
+        "[lease] (shin | shift)": "shift",
+        "ross (shin | shift)": "rshift",
+        "windows": "win",
     }
     combined_button_dictionary = {}
     for dictionary in [button_dictionary_1, button_dictionary_10, button_dictionary_500]:
         combined_button_dictionary.update(dictionary)
 
-    modifier_choice_object = Choice("modifier", {
+    pre_modifier_choice_object = Choice("pre_modifier", {
             "(control | fly)": "c-", #TODO: make DRY
             "(shift | shin)": "s-",
             "alt": "a-",
@@ -265,6 +269,11 @@ class Navigation(MergeRule):
             "control windows alt shift": "cwas-",
             "hit": "",
         })
+
+    post_modifier_choice_object = Choice("post_modifier", {
+            "hold": "down",
+            "release": "up"
+        })
     extras = [
         IntegerRefST("nnavi10", 1, 11),
         IntegerRefST("nnavi3", 1, 4),
@@ -278,7 +287,8 @@ class Navigation(MergeRule):
             "lease": "left",
             "ross": "right",
         }),
-        modifier_choice_object,
+        pre_modifier_choice_object,
+        post_modifier_choice_object,
         Choice("button_dictionary_1", button_dictionary_1),
         Choice("button_dictionary_10", button_dictionary_10),
         Choice("button_dictionary_500", button_dictionary_500),
@@ -344,7 +354,7 @@ class Navigation(MergeRule):
         "extreme": None,
         "big": False,
         "splatdir": "backspace",
-        "modifier": "",
+        "pre_modifier": "",
     }
 
 

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -246,6 +246,7 @@ class Navigation(MergeRule):
         "seven": "7",
         "eight": "8",
         "nine": "9",
+        "windows": "win"
     }
     button_dictionary_1.update(modifier_button_dictionary)
     combined_button_dictionary = {}

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -185,9 +185,9 @@ class Navigation(MergeRule):
         "<pre_modifier> <button_dictionary_1>":
               R(Key("%(pre_modifier)s%(button_dictionary_1)s"),
               rdescript="press pre_modifiers plus buttons from button_dictionary_1, non-repeatable"),
-        "<post_modifier> <button_dictionary_1>":
-              R(Key("%(button_dictionary_1)s:%(post_modifier)s"),
-              rdescript="press buttons from button_dictionary_1 with post modifier, non-repeatable"),
+        "<post_modifier> <modifier_button_dictionary>":
+              R(Key("%(modifier_button_dictionary)s:%(post_modifier)s"),
+              rdescript="press buttons from modifier_button_dictionary with post modifier, non-repeatable"),
     }
     tell_commands_dict = {"dock": ";", "doc": ";", "sink": "", "com": ",", "deck": ":"}
     tell_commands_dict.update(_tpd)
@@ -224,6 +224,14 @@ class Navigation(MergeRule):
         "backslash": "backslash"
     }
     button_dictionary_10.update(longhand_punctuation_names)
+    modifier_button_dictionary = {
+        "[lease | left] alt": "alt",
+        "(ross | right) alt": "ralt",
+        "[lease | left] (control | fly)": "control",
+        "(ross | right) (control | fly)": "rcontrol",
+        "[lease | left] (shin | shift)": "shift",
+        "(ross | right) (shin | shift)": "rshift",
+    }
     button_dictionary_1 = {
         "(home | lease wally | latch)": "home",
         "(end | ross wally | ratch)": "end",
@@ -238,14 +246,8 @@ class Navigation(MergeRule):
         "seven": "7",
         "eight": "8",
         "nine": "9",
-        "[lease] alt": "alt",
-        "ross alt": "ralt",
-        "[lease] (control | fly)": "control",
-        "ross (control | fly)": "rcontrol",
-        "[lease] (shin | shift)": "shift",
-        "ross (shin | shift)": "rshift",
-        "windows": "win",
     }
+    button_dictionary_1.update(modifier_button_dictionary)
     combined_button_dictionary = {}
     for dictionary in [button_dictionary_1, button_dictionary_10, button_dictionary_500]:
         combined_button_dictionary.update(dictionary)
@@ -292,6 +294,7 @@ class Navigation(MergeRule):
         Choice("button_dictionary_1", button_dictionary_1),
         Choice("button_dictionary_10", button_dictionary_10),
         Choice("button_dictionary_500", button_dictionary_500),
+        Choice("modifier_button_dictionary", modifier_button_dictionary),
         Choice("combined_button_dictionary", combined_button_dictionary),
 
         Choice("capitalization", {


### PR DESCRIPTION
# Add hold and release

## Description

This PR adds hold and release for control, shift, and alt. It uses the existing caster specs (e.g. fly | control). It also adds those keys (along with the windows key) to button_dictionary_1.

## Related Issue

None.

## Motivation and Context

Pressing the modifier keys was missing from Caster (it is available natively in Dragon using the prefix "press"). Holding and releasing is sometimes desired for these keys as well. If others have use cases for holding and releasing other keys (like "hold lease") then we can consider adding those as well.

## How Has This Been Tested

Tested using the test engine for each new command.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [ ] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
