### PR TITLE
Add contexts for cross platform

### DIFF
--- a/castervoice/lib/contexts.py
+++ b/castervoice/lib/contexts.py
@@ -26,6 +26,4 @@ DIALOGUE_CONTEXT = AppContext(title=[
         "open",
         "save",
         "select",
-        "Open Project",
-        "Choose Directory"
     ])

--- a/castervoice/lib/contexts.py
+++ b/castervoice/lib/contexts.py
@@ -1,11 +1,20 @@
+import os
+import sys
+from dragonfly import FuncContext
 from castervoice.lib.context import AppContext
+
+WINDOWS_CONTEXT = FuncContext(lambda: sys.platform == "win32")
+MACOS_CONTEXT = FuncContext(lambda: sys.platform == "darwin")
+LINUX_CONTEXT = FuncContext(lambda: sys.platform.startswith("linux"))
+X11_CONTEXT = FuncContext(lambda: os.environ.get("XDG_SESSION_TYPE") == "x11")
 
 TERMINAL_CONTEXT = AppContext(executable=[
     "\\sh.exe",
     "\\bash.exe",
     "\\cmd.exe",
     "\\mintty.exe",
-    "\\powershell.exe"
+    "\\powershell.exe",
+    "gnome-terminal"
     ])
 
 JETBRAINS_CONTEXT = AppContext(executable="idea", title="IntelliJ") \
@@ -17,4 +26,6 @@ DIALOGUE_CONTEXT = AppContext(title=[
         "open",
         "save",
         "select",
+        "Open Project",
+        "Choose Directory"
     ])


### PR DESCRIPTION
# Add contexts for cross platform

## Description

Adds contexts for cross platform as per https://github.com/dictation-toolbox/dragonfly/issues/293

## Related Issue

None.

## Motivation and Context

Allows for platform contexts to be used in ContextAction.

## How Has This Been Tested

In a ContextAction on another branch.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
