### PR TITLE
add six to requirements (pretty trivial)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ appdirs>=1.4.3
 scandir>=1.10.0
 pylint
 pyvda
+six

--- a/requirements-mac-linux.txt
+++ b/requirements-mac-linux.txt
@@ -8,3 +8,4 @@ appdirs>=1.4.3
 scandir>=1.10.0
 pylint
 PySide2
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pyvda
+six


### PR DESCRIPTION
Found that this stopped caster working after a reinstall.

Current version is 1.15, do we want to specify version greater than that?