### PR TITLE
kaldi default mic state "on" for sleep_timer

### DIFF
--- a/castervoice/lib/ctrl/configure_engine.py
+++ b/castervoice/lib/ctrl/configure_engine.py
@@ -35,6 +35,9 @@ class EngineConfigLate:
 
     def __init__(self):
         self.EngineModesManager.initialize()
+        if self.engine == 'kaldi':
+            # kaldi needs a default mic state for sleep_timer
+            self.EngineModesManager.mic_state = "on"
         if self.engine != "text":
             self._engine_timers()
             self._set_default_mic_mode()


### PR DESCRIPTION
# Title

kaldi needs a default mic state "on" for sleep_timer

## Description

The sleep timer checks the current mic state every X seconds (Default 120). At the interval of the timer if the microphone is "on" the microphone will be put to sleep.

## Related Issue

_Originally posted by @kendonB in https://github.com/dictation-toolbox/Caster/pull/856#issuecomment-709643781_

## Motivation and Context

```
@LexiconCode on Kaldi there's a limitation in that the timer is not on until you load the sleeping grammar and that is only loaded once you first say "caster sleep" or "caster on". Is there a way we can turn this on right when caster starts?
```
## How Has This Been Tested

Kaldi and DNS

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.
