### PR TITLE
add missing keyboard keys

### DIFF
--- a/castervoice/rules/core/keyboard_rules/keyboard.py
+++ b/castervoice/rules/core/keyboard_rules/keyboard.py
@@ -36,10 +36,10 @@ class Keyboard(MappingRule):
     mapping = {
         "<modifier> <button_dictionary_1>":
               R(Key("%(modifier)s%(button_dictionary_1)s"),
-              rdescript="press modifiers plus buttons from button_dictionary_1, non-repeatable"),
-        "<hold_release> [<modifier>] <button_dictionary_1>":
-              R(Key("%(modifier)s%(button_dictionary_1)s:%(hold_release)s"),
-              rdescript="press modifiers plus buttons from button_dictionary_1, non-repeatable"),
+              rdescript="press button: %(modifier)s%(button_dictionary_1)s"),
+        "<hold_release> <button_dictionary_1>":
+              R(Key("%(button_dictionary_1)s:%(hold_release)s"),
+              rdescript="%(hold_release)s button: %(button_dictionary_1)s"),
     }
 
     # These buttons can be used without using the "press" prefix.
@@ -56,11 +56,16 @@ class Keyboard(MappingRule):
     alt_spec = "alt"
     windows_spec = "windows"
     # in the punctuation dictionary it uses " " which is not the correct dragonfly key name.
-    del button_dictionary_1["ace"]
     del button_dictionary_1["[is] less [than] [or] equal [to]"]
     del button_dictionary_1["[is] equal to"]
     del button_dictionary_1["[is] greater [than] [or] equal [to]"]
- 
+
+    ace_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(' ')]
+    slash_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index('/')]
+    minus_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index('-')]
+    colon_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(':')]
+    comma_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(',')]
+
     button_dictionary_1.update({
         "(tab | tabby)": "tab",
         "(backspace | clear)": "backspace",
@@ -72,7 +77,11 @@ class Keyboard(MappingRule):
         "(down | dunce)": "down",
         "page (down | dunce)": "pgdown",
         "page (up | sauce)": "pgup",
-        "ace": "space",
+        ace_key: "space",
+        comma_key: "comma",
+        minus_key: "minus",
+        slash_key: "slash",
+        colon_key: "colon",
         "zero": "0",
         "one": "1",
         "two": "2",

--- a/castervoice/rules/core/keyboard_rules/keyboard.py
+++ b/castervoice/rules/core/keyboard_rules/keyboard.py
@@ -32,6 +32,17 @@ cat_spec_and_reverse = lambda s1, s2: "(" + s1 + " " + s2 + ")" + " | " + "(" + 
 
 cat_spec_and_reverse_3 = lambda s1, s2, s3: cat_spec_and_reverse(cat_spec_and_reverse(s1, s2), s3) + " | (" + s1 + " " + s3 + " " + s2 + ")" + " | (" + s2 + " " + s3 + " " + s1 + ")" + " | (" + s3 + " " + s2 + " " + s1 + ")"
 
+button_dictionary_1 = {
+    "(F{}".format(i) + " | function {})".format(i) : "f{}".format(i)
+    for i in range(1, 13)
+    }
+
+def getspec(value, dct=button_dictionary_1):
+    # Reverses Keys and Values which allows for dct.get(value)
+    # The returned String is the spoken spec for the command
+    reversed_dictionary = dict(map(reversed, dct.items()))
+    return reversed_dictionary.get(value)
+
 class Keyboard(MappingRule):
     mapping = {
         "<modifier> <button_dictionary_1>":
@@ -45,10 +56,6 @@ class Keyboard(MappingRule):
     # These buttons can be used without using the "press" prefix.
     right_spec = "(right | ross)"
     left_spec = "(left | lease)"
-    button_dictionary_1 = {
-        "(F{}".format(i) + " | function {})".format(i) : "f{}".format(i)
-        for i in range(1, 13)
-    }
     button_dictionary_1.update(caster_alphabet())
     button_dictionary_1.update(_tpd)
     shift_spec = "(shift | shin)"
@@ -59,12 +66,6 @@ class Keyboard(MappingRule):
     del button_dictionary_1["[is] less [than] [or] equal [to]"]
     del button_dictionary_1["[is] equal to"]
     del button_dictionary_1["[is] greater [than] [or] equal [to]"]
-
-    ace_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(' ')]
-    slash_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index('/')]
-    minus_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index('-')]
-    colon_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(':')]
-    comma_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(',')]
 
     button_dictionary_1.update({
         "(tab | tabby)": "tab",
@@ -77,11 +78,11 @@ class Keyboard(MappingRule):
         "(down | dunce)": "down",
         "page (down | dunce)": "pgdown",
         "page (up | sauce)": "pgup",
-        ace_key: "space",
-        comma_key: "comma",
-        minus_key: "minus",
-        slash_key: "slash",
-        colon_key: "colon",
+        getspec(' '): "space",
+        getspec(','): "comma",
+        getspec('-'): "minus",
+        getspec('/'): "slash",
+        getspec(':'): "colon",
         "zero": "0",
         "one": "1",
         "two": "2",
@@ -149,4 +150,3 @@ class Keyboard(MappingRule):
 
 def get_rule():
     return Keyboard, RuleDetails(name = "keyboard")
-


### PR DESCRIPTION
# add missing keyboard keys

## Description

The keyboard grammar had used the punctuation keys from punctuation_support but not all of those characters (passed to `Text` in punctuation.py) exist in the dragonfly keyboard specification. This PR replaces those characters (" ", "-", "/", ",", and ":") with their respective dragonfly Key IDs ("space", "minus", "slash", "comma", and "colon").

The approach should be robust to people editing the specs in punctuation_support.

## Related Issue

None. Mentioned on gitter

## Motivation and Context

Fixing a bug

## How Has This Been Tested

Just using the text engine

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.
