### PR TITLE
Re-factor keyboard dictionaries to keyboard_support

### DIFF
--- a/castervoice/rules/ccr/voice_dev_commands_rules/voice_dev_commands.py
+++ b/castervoice/rules/ccr/voice_dev_commands_rules/voice_dev_commands.py
@@ -9,14 +9,14 @@ from dragonfly import Pause, Choice, Dictation, Function
 from dragonfly.actions.action_mouse import get_cursor_position
 
 from castervoice.lib.actions import Text, Key
-from castervoice.rules.core.keyboard_rules.keyboard import Keyboard
+from castervoice.rules.core.keyboard_rules import keyboard_support
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
-new_modifier_choice_object = copy.deepcopy(Keyboard.modifier_choice_object)
+new_modifier_choice_object = copy.deepcopy(keyboard_support.modifier_choice_object)
 
 def split_dictation(text):
     if text:
@@ -199,7 +199,7 @@ class VoiceDevCommands(MergeRule):
 
     extras = [
         new_modifier_choice_object,
-        Choice("button_dictionary_1", Keyboard.button_dictionary_1),
+        Choice("button_dictionary_1", keyboard_support.button_dictionary_1),
         Dictation("text"),
         Dictation("dict"),
         Dictation("spec"),

--- a/castervoice/rules/core/keyboard_rules/keyboard.py
+++ b/castervoice/rules/core/keyboard_rules/keyboard.py
@@ -1,36 +1,11 @@
-from dragonfly import Function, Repeat, Dictation, Choice, ContextAction, MappingRule
-from castervoice.lib.context import AppContext
+from dragonfly import Choice, MappingRule
 
-from castervoice.lib import navigation, context, textformat, text_utils
-from castervoice.rules.core.navigation_rules import navigation_support
-from dragonfly.actions.action_mimic import Mimic
+from castervoice.rules.core.keyboard_rules import keyboard_support
+from castervoice.lib.actions import Key
 
-from castervoice.lib.actions import Key, Mouse
-from castervoice.rules.ccr.standard import SymbolSpecs
-
-try:  # Try first loading from caster user directory
-    from alphabet_rules.alphabet_support import caster_alphabet
-except ImportError: 
-    from castervoice.rules.core.alphabet_rules.alphabet_support import caster_alphabet
-
-try:  # Try  first loading  from caster user directory
-    from punctuation_rules.punctuation_support import double_text_punc_dict, text_punc_dict
-except ImportError: 
-    from castervoice.rules.core.punctuation_rules.punctuation_support import double_text_punc_dict, text_punc_dict
-
-from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
-from castervoice.lib.merge.mergerule import MergeRule
-from castervoice.lib.merge.state.actions import AsynchronousAction, ContextSeeker
-from castervoice.lib.merge.state.actions2 import UntilCancelled
-from castervoice.lib.merge.state.short import S, L, R
+from castervoice.lib.merge.state.short import R
 
-_tpd = text_punc_dict()
-
-cat_spec_and_reverse = lambda s1, s2: "(" + s1 + " " + s2 + ")" + " | " + "(" + s2 + " " + s1 + ")"
-
-cat_spec_and_reverse_3 = lambda s1, s2, s3: "(" + s1 + " (" + cat_spec_and_reverse(s2, s3) + ")) | (" + s2 + " (" + cat_spec_and_reverse(s1, s3) + ")) | (" + s3 + " (" + cat_spec_and_reverse(s1, s2) + "))"
 
 class Keyboard(MappingRule):
     mapping = {
@@ -42,101 +17,9 @@ class Keyboard(MappingRule):
               rdescript="%(hold_release)s button: %(button_dictionary_1)s"),
     }
 
-    # These buttons can be used without using the "press" prefix.
-    right_spec = "(right | ross)"
-    left_spec = "(left | lease)"
-    button_dictionary_1 = {
-        "(F{}".format(i) + " | function {})".format(i) : "f{}".format(i)
-        for i in range(1, 13)
-    }
-    button_dictionary_1.update(caster_alphabet())
-    button_dictionary_1.update(_tpd)
-    shift_spec = "(shift | shin)"
-    control_spec = "(control | fly)"
-    alt_spec = "alt"
-    windows_spec = "windows"
-    # in the punctuation dictionary it uses " " which is not the correct dragonfly key name.
-    del button_dictionary_1["[is] less [than] [or] equal [to]"]
-    del button_dictionary_1["[is] equal to"]
-    del button_dictionary_1["[is] greater [than] [or] equal [to]"]
-
-    ace_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(' ')]
-    slash_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index('/')]
-    minus_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index('-')]
-    colon_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(':')]
-    comma_key = list(button_dictionary_1.keys())[list(button_dictionary_1.values()).index(',')]
-
-    button_dictionary_1.update({
-        "(tab | tabby)": "tab",
-        "(backspace | clear)": "backspace",
-        "(delete | deli)": "del",
-        "(enter | shock)": "enter",
-        left_spec: "left",
-        right_spec: "right",
-        "(up | sauce)": "up",
-        "(down | dunce)": "down",
-        "page (down | dunce)": "pgdown",
-        "page (up | sauce)": "pgup",
-        ace_key: "space",
-        comma_key: "comma",
-        minus_key: "minus",
-        slash_key: "slash",
-        colon_key: "colon",
-        "zero": "0",
-        "one": "1",
-        "two": "2",
-        "three": "3",
-        "four": "4",
-        "five": "5",
-        "six": "6",
-        "seven": "7",
-        "eight": "8",
-        "nine": "9",
-        shift_spec: "shift",
-        control_spec: "control",
-        alt_spec: "alt",
-        right_spec + " " + shift_spec: "rshift",
-        right_spec + " " + control_spec: "rcontrol",
-        right_spec + " " + alt_spec: "ralt",
-        SymbolSpecs.CANCEL: "escape",
-        "insert": "insert",
-        "pause": "pause",
-        windows_spec: "win",
-        "(apps | popup)": "apps",
-        "print screen": "printscreen",
-        "scroll lock": "scrolllock",
-        "num lock": "numlock",
-        "caps lock": "capslock",
-        "(home | lease wally | latch)": "home",
-        "(end | ross wally | ratch)": "end",
-        # number pad numbers deliberately left off
-        # volume control deliberately left off as these are dealt with in HardwareRule and I don't think there's a use case for modifiers there
-        # track control deliberately left off as these are (or will be) dealt with in HardwareRule and I don't think there's a use case for modifiers there
-        # browser forward/back are deliberately left off. These functions are implemented at the browser rule level
-    })
-    
-    modifier_choice_object = Choice("modifier", {
-            control_spec: "c-",
-            shift_spec: "s-",
-            alt_spec: "a-",
-            cat_spec_and_reverse(control_spec, shift_spec) + " | queue": "cs-",
-            cat_spec_and_reverse(control_spec, alt_spec): "ca-",
-            cat_spec_and_reverse(alt_spec, shift_spec): "sa-",
-            cat_spec_and_reverse_3(alt_spec, control_spec, shift_spec): "csa-",
-            windows_spec: "w-",
-            cat_spec_and_reverse(control_spec, windows_spec): "cw-",
-            cat_spec_and_reverse_3(alt_spec, control_spec, windows_spec): "cwa-",
-            cat_spec_and_reverse_3(shift_spec, control_spec, windows_spec): "cws-",
-            cat_spec_and_reverse_3(alt_spec, shift_spec, windows_spec): "wsa-",
-            cat_spec_and_reverse(windows_spec, shift_spec): "ws-",
-            cat_spec_and_reverse(windows_spec, alt_spec): "wa-",
-            # We will leave this as is as it is seldom used
-            "control windows alt shift": "cwas-",
-            "press": "",
-        })
     extras = [
-        modifier_choice_object,
-        Choice("button_dictionary_1", button_dictionary_1),
+        keyboard_support.modifier_choice_object,
+        Choice("button_dictionary_1", keyboard_support.button_dictionary_1),
         Choice("hold_release", {
             "hold": "down",
             "release": "up"
@@ -149,4 +32,3 @@ class Keyboard(MappingRule):
 
 def get_rule():
     return Keyboard, RuleDetails(name = "keyboard")
-

--- a/castervoice/rules/core/keyboard_rules/keyboard_support.py
+++ b/castervoice/rules/core/keyboard_rules/keyboard_support.py
@@ -1,0 +1,131 @@
+from castervoice.rules.ccr.standard import SymbolSpecs
+from dragonfly import Choice
+
+try:  # Try first loading from caster user directory
+    from alphabet_rules.alphabet_support import caster_alphabet
+except ImportError: 
+    from castervoice.rules.core.alphabet_rules.alphabet_support import caster_alphabet
+
+try:  # Try  first loading from caster user directory
+    from punctuation_rules.punctuation_support import text_punc_dict
+except ImportError: 
+    from castervoice.rules.core.punctuation_rules.punctuation_support import text_punc_dict
+ 
+ 
+right_spec = "(right | ross)"
+left_spec = "(left | lease)"
+
+shift_spec = "(shift | shin)"
+control_spec = "(control | fly)"
+alt_spec = "alt"
+windows_spec = "windows"
+
+
+def get_modifiers():
+    cat_spec_and_reverse = lambda s1, s2: "(" + s1 + " " + s2 + ")" + " | " + "(" + s2 + " " + s1 + ")"
+    cat_spec_and_reverse_3 = lambda s1, s2, s3: "(" + s1 + " (" + cat_spec_and_reverse(s2, s3) + ")) | (" + s2 + " (" + cat_spec_and_reverse(s1, s3) + ")) | (" + s3 + " (" + cat_spec_and_reverse(s1, s2) + "))"
+    modifiers = {
+                control_spec: "c-",
+                shift_spec: "s-",
+                alt_spec: "a-",
+                cat_spec_and_reverse(control_spec, shift_spec) + " | queue": "cs-",
+                cat_spec_and_reverse(control_spec, alt_spec): "ca-",
+                cat_spec_and_reverse(alt_spec, shift_spec): "sa-",
+                cat_spec_and_reverse_3(alt_spec, control_spec, shift_spec): "csa-",
+                windows_spec: "w-",
+                cat_spec_and_reverse(control_spec, windows_spec): "cw-",
+                cat_spec_and_reverse_3(alt_spec, control_spec, windows_spec): "cwa-",
+                cat_spec_and_reverse_3(shift_spec, control_spec, windows_spec): "cws-",
+                cat_spec_and_reverse_3(alt_spec, shift_spec, windows_spec): "wsa-",
+                cat_spec_and_reverse(windows_spec, shift_spec): "ws-",
+                cat_spec_and_reverse(windows_spec, alt_spec): "wa-",
+                # We will leave this as is as it is seldom used
+                "control windows alt shift": "cwas-",
+                "press": "",
+            }
+
+    return modifiers
+            
+
+modifier_choice_object = Choice("modifier", get_modifiers())
+
+class ButtonDict():
+    button_dictionary = {
+            "(F{}".format(i) + " | function {})".format(i) : "f{}".format(i)
+            for i in range(1, 13)}
+    reversed_button_dictionary = None
+   
+    def getdict(self):
+        self.updatedict()
+        self.removekeys()
+        return(self.button_dictionary)
+        
+    def getspec(self, value, dct=button_dictionary):
+        # Reverses Keys and Values which allows for dct.get(value)
+        # The returned String is the spoken spec for the command
+        if self.reversed_button_dictionary is None:
+            self.reversed_button_dictionary = dict(map(reversed, dct.items()))
+        return self.reversed_button_dictionary.get(value)
+
+    def updatedict(self):
+        self.button_dictionary.update(caster_alphabet())
+        self.button_dictionary.update(text_punc_dict())
+        self.button_dictionary.update({
+                "(tab | tabby)": "tab",
+                "(backspace | clear)": "backspace",
+                "(delete | deli)": "del",
+                "(enter | shock)": "enter",
+                left_spec: "left",
+                right_spec: "right",
+                "(up | sauce)": "up",
+                "(down | dunce)": "down",
+                "page (down | dunce)": "pgdown",
+                "page (up | sauce)": "pgup",
+                "zero": "0",
+                "one": "1",
+                "two": "2",
+                "three": "3",
+                "four": "4",
+                "five": "5",
+                "six": "6",
+                "seven": "7",
+                "eight": "8",
+                "nine": "9",
+                shift_spec: "shift",
+                control_spec: "control",
+                alt_spec: "alt",
+                right_spec + " " + shift_spec: "rshift",
+                right_spec + " " + control_spec: "rcontrol",
+                right_spec + " " + alt_spec: "ralt",
+                SymbolSpecs.CANCEL: "escape",
+                "insert": "insert",
+                "pause": "pause",
+                windows_spec: "win",
+                "(apps | popup)": "apps",
+                "print screen": "printscreen",
+                "scroll lock": "scrolllock",
+                "num lock": "numlock",
+                "caps lock": "capslock",
+                "(home | lease wally | latch)": "home",
+                "(end | ross wally | ratch)": "end",
+                # number pad numbers deliberately left off
+                # volume control deliberately left off as these are dealt with in HardwareRule and I don't think there's a use case for modifiers there
+                # track control deliberately left off as these are (or will be) dealt with in HardwareRule and I don't think there's a use case for modifiers there
+                # browser forward/back are deliberately left off. These functions are implemented at the browser rule level
+            })
+        
+        self.button_dictionary.update({
+                self.getspec(' '): "space",
+                self.getspec(','): "comma",
+                self.getspec('-'): "minus",
+                self.getspec('/'): "slash",
+                self.getspec(':'): "colon",
+            })
+    def removekeys(self):
+        # in the punctuation dictionary it uses " " which is not the correct dragonfly key name.
+        del self.button_dictionary["[is] less [than] [or] equal [to]"]
+        del self.button_dictionary["[is] equal to"]
+        del self.button_dictionary["[is] greater [than] [or] equal [to]"]
+       
+
+button_dictionary_1 = ButtonDict().getdict()

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -17,12 +17,12 @@ except ImportError:
         from castervoice.rules.core.punctuation_rules.punctuation_support import double_text_punc_dict, text_punc_dict
 
 try:
-    from keyboard_rules.keyboard import Keyboard
+    from keyboard_rules import keyboard_support
 except ImportError: 
     try:
-        from keyboard import Keyboard
+        from keyboard_support import keyboard_support
     except ImportError: 
-        from castervoice.rules.core.keyboard_rules.keyboard import Keyboard
+        from castervoice.rules.core.keyboard_rules import keyboard_support
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
@@ -198,12 +198,12 @@ class Navigation(MergeRule):
         "page (up | sauce)": "pgup",
     }
     button_dictionary_500_modifier = { 
-        key:value for key, value in Keyboard.button_dictionary_1.items() if value in [
+        key:value for key, value in keyboard_support.button_dictionary_1.items() if value in [
             "backspace", "del", "enter", "left", "right", "up", "down", "pgdown", "pgup"
             ]
     }
     button_dictionary_1_modifier = { 
-        key:value for key, value in Keyboard.button_dictionary_1.items() if value in [
+        key:value for key, value in keyboard_support.button_dictionary_1.items() if value in [
             "home", "end"
             ]
     }    
@@ -254,7 +254,7 @@ class Navigation(MergeRule):
             "lease": "backspace",
             "ross": "delete",
         }),
-        Keyboard.modifier_choice_object,
+        keyboard_support.modifier_choice_object,
         Choice("button_dictionary_500_no_prefix_no_modifier", button_dictionary_500_no_prefix_no_modifier),
         Choice("button_dictionary_500_modifier", button_dictionary_500_modifier),
         Choice("button_dictionary_1_modifier", button_dictionary_1_modifier)        

--- a/tests/rules/core/test_rule_modules.py
+++ b/tests/rules/core/test_rule_modules.py
@@ -5,6 +5,7 @@ class CoreModulesTestCase(ModulesTestCase):
     def _rule_modules(self):
         from castervoice.rules.core.text_manipulation_rules import text_manipulation
         from castervoice.rules.core.numbers_rules import numeric
+        from castervoice.rules.core.keyboard_rules import keyboard
         from castervoice.rules.core.navigation_rules import nav
         from castervoice.rules.core.navigation_rules import nav2
         from castervoice.rules.core.navigation_rules import window_mgmt_rule
@@ -14,6 +15,6 @@ class CoreModulesTestCase(ModulesTestCase):
         from castervoice.rules.core.utility_rules import hardware_rule
         from castervoice.rules.core.utility_rules import mouse_alts_rules
 
-        return [alphabet, nav, nav2, window_mgmt_rule, numeric, punctuation,
+        return [alphabet, nav, nav2, window_mgmt_rule, numeric, keyboard, punctuation,
                 text_manipulation, caster_rule,
                 hardware_rule, mouse_alts_rules]


### PR DESCRIPTION
## Description

- Refactors much of what was in the keyboard class into the keyboard_support.
- Cleans unused imports from keyboard.py
- Adds keyboard.py to unit tests

## Related Issue

None

## Motivation and Context

- It's unclear and difficult to manage when importing the keyboard class changes to choice objects. 
	Choice objects that are imported by other grammars should be in support files.

The support files are imported only twice. Once to verify validity of Python on startup and once for all grammars regardless the number of imports of the keyboard support. ButtonDict in the support file now has a clear structure for ordering updates to the dictionary. Both modifier_choice_object and button_dictionary_1 have functions that scoped variables and execution order.

## How Has This Been Tested

Testing a number of commands manually. It's too large to test all keyboard keys but it should be representative and function the same as the current master.

note: any fixes with keyboard grammar does not hold modifier keys #877 would need to be carried over to this PR. considered a work in progress until the above issue is resolved.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
