### PR TITLE
Remove IntegerRefST

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -38,3 +38,6 @@ if settings.SETTINGS["sikuli"]["enabled"]:
     sikuli_controller.get_instance().bootstrap_start_server_proxy()
 
 print("\n*- Starting " + settings.SOFTWARE_NAME + " -*")
+
+for message in settings.STARTUP_MESSAGES:
+    print("\n" + message + "\n")

--- a/castervoice/asynch/hmc_rules/hmc_history_rule.py
+++ b/castervoice/asynch/hmc_rules/hmc_history_rule.py
@@ -1,8 +1,7 @@
-from dragonfly import Function, MappingRule
+from dragonfly import Function, MappingRule, ShortIntegerRef
 
 from castervoice.lib import control, settings
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -36,8 +35,8 @@ class HMCHistoryRule(MappingRule):
             R(Function(hmc_recording_repeatable))
     }
     extras = [
-        IntegerRefST("n", 1, 25),
-        IntegerRefST("n2", 1, 25),
+        ShortIntegerRef("n", 1, 25),
+        ShortIntegerRef("n2", 1, 25),
     ]
 
 

--- a/castervoice/bin/share/API command grammars example/browser/browser_shared.py
+++ b/castervoice/bin/share/API command grammars example/browser/browser_shared.py
@@ -2,10 +2,9 @@
 #
 # __author__ = "lexxish"
 #
-from dragonfly import Choice
+from dragonfly import Choice, ShortIntegerRef
 
 from castervoice.rules.apps.shared.directions import FORWARD, RIGHT, BACK, LEFT
-from castervoice.lib.merge.additions import IntegerRefST
 
 OPEN_NEW_WINDOW = "(new window|win new)"
 OPEN_NEW_INCOGNITO_WINDOW = "(new incognito window | incognito)"
@@ -70,6 +69,6 @@ def get_extras():
             "seventh": "7",
             "eighth": "8",
         }),
-        IntegerRefST("n", 1, 100),
-        IntegerRefST("m", 1, 10)
+        ShortIntegerRef("n", 1, 100),
+        ShortIntegerRef("m", 1, 10)
     ]

--- a/castervoice/bin/share/API command grammars example/editor/ide/jetbrains.py
+++ b/castervoice/bin/share/API command grammars example/editor/ide/jetbrains.py
@@ -1,10 +1,9 @@
 # pylint: skip-file
-from dragonfly import Dictation, Repeat, MappingRule
+from dragonfly import Dictation, Repeat, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Text, Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 import ide_shared
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -12,7 +11,7 @@ class JetbrainsRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
 
     DELAY = "20"

--- a/castervoice/lib/dev/dev.py
+++ b/castervoice/lib/dev/dev.py
@@ -6,12 +6,12 @@ import threading
 import shlex
 
 from dragonfly import (Function, BringApp, WaitWindow, Dictation, Choice, Grammar,
-                       MappingRule, Paste)
+                       MappingRule, Paste, ShortIntegerRef)
 
 from castervoice.lib import utilities, settings, context, control
 from castervoice.lib.dev import devgen
 from castervoice.lib.actions import Key, Text
-from castervoice.lib.merge.additions import IntegerRefST
+
 from castervoice.lib.merge.state.actions import ContextSeeker, AsynchronousAction, \
     RegisteredAction
 from castervoice.lib.merge.state.actions2 import NullAction, ConfirmAction, \
@@ -133,7 +133,7 @@ class Experimental(MappingRule):
         #     "dredge [<id> <text>]":         Function(dredge),
         "test dragonfly paste": Paste("some text"),
     }
-    extras = [Dictation("text"), Dictation("text2"), IntegerRefST("n2", 1, 100)]
+    extras = [Dictation("text"), Dictation("text2"), ShortIntegerRef("n2", 1, 100)]
     defaults = {"text": "", "text2": ""}
 
 
@@ -224,7 +224,7 @@ class StackTest(MappingRule):
                 box_type=settings.QTYPE_DEFAULT,
                 log_failure=True),
     }
-    extras = [Dictation("text"), Dictation("text2"), IntegerRefST("n", 1, 5)]
+    extras = [Dictation("text"), Dictation("text2"), ShortIntegerRef("n", 1, 5)]
     defaults = {"text": "", "text2": ""}
 
 

--- a/castervoice/lib/merge/additions.py
+++ b/castervoice/lib/merge/additions.py
@@ -1,10 +1,18 @@
 from dragonfly import ShortIntegerRef
 from dragonfly.grammar.elements import Choice
+from castervoice.lib import settings 
 
-IntegerRefST = ShortIntegerRef
-# Compatibility shim for older grammars that use IntegerRefST.
-# IntegerRefST and Integer Remap has deprecated.
-# Use dragonfly ShortIntegerRef
+
+class IntegerRefST(ShortIntegerRef):
+    """
+    Compatibility shim for older grammars that use IntegerRefST.
+    IntegerRefST and Integer Remap has been removed use dragonfly ShortIntegerRef
+    """
+
+    def __init__(self, name, min, max, default=None):
+        message = "Detected 'IntegerRefST' import in rules/grammars.\nIntegerRefST and Integer Remap has been removed. \nUpdate your rules to `from dragonfly import ShortIntegerRef` in instead of IntegerRefST" 
+        settings.add_message(message)
+        super(IntegerRefST, self).__init__(name, min, max, default)
 
 
 class Boolean(Choice):

--- a/castervoice/lib/merge/additions.py
+++ b/castervoice/lib/merge/additions.py
@@ -1,35 +1,10 @@
-from dragonfly import (IntegerRef, Integer)
-from dragonfly.grammar.elements import RuleWrap, Choice
-from dragonfly.language.base.integer_internal import MapIntBuilder
-from dragonfly.language.loader import language
+from dragonfly import ShortIntegerRef
+from dragonfly.grammar.elements import Choice
 
-from castervoice.lib import settings
-from castervoice.rules.core.numbers_rules.numeric_support import numbers_map_1_to_9  # Conditional import load from user directory?
-
-'''
-Integer Remap feature needs to be rewritten:
-    - allow customization
-    - make it language sensitive (can this be done without eval?)
-''' 
-if not settings.settings(["miscellaneous", "integer_remap_crash_fix"]):
-    class IntegerRefST(RuleWrap):
-        def __init__(self, name, min, max, default=None):
-            if not settings.settings(["miscellaneous", "short_integer_opt_out"]):
-                content = language.ShortIntegerContent
-            else:
-                content = language.IntegerContent
-                
-            if "en" in language.language_map and settings.settings(["miscellaneous", "integer_remap_opt_in"]):
-                content.builders[1] = MapIntBuilder(numbers_map_1_to_9())
-
-            element = Integer(None, min, max, content=content)
-            RuleWrap.__init__(self, name, element, default=default)
-            
-else:
-    print("Integer Remap switch: OFF")
-
-    class IntegerRefST(IntegerRef):
-        ''''''
+IntegerRefST = ShortIntegerRef
+# Compatibility shim for older grammars that use IntegerRefST.
+# IntegerRefST and Integer Remap has deprecated.
+# Use dragonfly ShortIntegerRef
 
 
 class Boolean(Choice):

--- a/castervoice/lib/merge/selfmod/selfmodrule.py
+++ b/castervoice/lib/merge/selfmod/selfmodrule.py
@@ -1,8 +1,7 @@
-from dragonfly.grammar.elements import Dictation
+from dragonfly import Dictation, IntegerRef, ShortIntegerRef
 
 from castervoice.lib import printer
 from castervoice.lib.ctrl.mgr.errors.base_class_error import DontUseBaseClassError
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.selfmod.sm_config import SelfModStateSavingConfig
 from castervoice.lib.merge.state.actions2 import NullAction
@@ -25,7 +24,7 @@ class BaseSelfModifyingRule(MergeRule):
         default_smr_mapping = {"spec which gets replaced": NullAction()}
         self._smr_mapping = default_smr_mapping
         # extras and defaults may not get replaced:
-        self._smr_extras = [IntegerRefST("n", 1, 50), Dictation("s")]
+        self._smr_extras = [ShortIntegerRef("n", 1, 50), Dictation("s")]
         self._smr_defaults = {"n": 1, "s": ""}
 
         self._config = SelfModStateSavingConfig(config_path)

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -64,7 +64,7 @@ def add_message(message):
     """
     try:
         if message not in STARTUP_MESSAGES:
-            STARTUP_MESSAGES.append(message)
+            STARTUP_MESSAGES.append(str(message))
     except Exception as e:
         print(e)
 

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -381,9 +381,6 @@ def _get_defaults():
             "keypress_wait": 50,  # milliseconds
             "max_ccr_repetitions": 16,
             "atom_palette_wait": 30,  # hundredths of a second
-            "integer_remap_opt_in": False,
-            "short_integer_opt_out": False,
-            "integer_remap_crash_fix": False,
             "print_rdescripts": True,
             "history_playback_delay_secs": 1.0,
             "legion_vertical_columns": 30,

--- a/castervoice/lib/settings.py
+++ b/castervoice/lib/settings.py
@@ -47,6 +47,7 @@ QTYPE_DIRECTORY = "5"
 QTYPE_CONFIRM = "6"
 WXTYPE_SETTINGS = "7"
 HMC_SEPARATOR = "[hmc]"
+STARTUP_MESSAGES = []
 
 # calculated fields
 SETTINGS = None
@@ -56,6 +57,16 @@ _BASE_PATH = None
 _USER_DIR = None
 _SETTINGS_PATH = None
 
+def add_message(message):
+    """
+    Add string message to be printed when Caster initializes
+    message: str
+    """
+    try:
+        if message not in STARTUP_MESSAGES:
+            STARTUP_MESSAGES.append(message)
+    except Exception as e:
+        print(e)
 
 def _get_platform_information():
     """Return a dictionary containing platform-specific information."""

--- a/castervoice/rules/apps/atlassian/jira.py
+++ b/castervoice/rules/apps/atlassian/jira.py
@@ -1,6 +1,6 @@
+from dragonfly import ShortIntegerRef 
 from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from dragonfly import AppContext, Dictation, Function, MappingRule, Pause, Repeat
 from dragonfly.actions import ContextAction
@@ -79,7 +79,7 @@ class JiraRule(MappingRule):
 
     exported = True
     extras = [
-        IntegerRefST("nnavi10", 1, 11),
+        ShortIntegerRef("nnavi10", 1, 11),
         Dictation("action"),
     ]
     defaults = {

--- a/castervoice/rules/apps/browser/chrome.py
+++ b/castervoice/rules/apps/browser/chrome.py
@@ -1,8 +1,7 @@
-from dragonfly import Repeat, Pause, Function, Choice, MappingRule
+from dragonfly import Repeat, Pause, Function, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Mouse, Text
 
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 
@@ -133,8 +132,8 @@ class ChromeRule(MappingRule):
                 "seventh": "7",
                 "eighth": "8",
             }),
-        IntegerRefST("n", 1, 100),
-        IntegerRefST("m", 1, 10)
+        ShortIntegerRef("n", 1, 100),
+        ShortIntegerRef("m", 1, 10)
     ]
     defaults = {"n": 1, "m":"", "nth": ""}
 

--- a/castervoice/rules/apps/browser/firefox.py
+++ b/castervoice/rules/apps/browser/firefox.py
@@ -1,8 +1,7 @@
-from dragonfly import Repeat, Pause, Function, Choice, MappingRule
+from dragonfly import Repeat, Pause, Function, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Mouse, Text
 
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 
@@ -112,8 +111,8 @@ class FirefoxRule(MappingRule):
                 "seventh": "7",
                 "eighth": "8",
             }),
-        IntegerRefST("n", 1, 100),
-        IntegerRefST("m", 1, 10)
+        ShortIntegerRef("n", 1, 100),
+        ShortIntegerRef("m", 1, 10)
     ]
     defaults = {"n": 1, "m":"", "nth": ""}
 

--- a/castervoice/rules/apps/chat/MSTeamsRule.py
+++ b/castervoice/rules/apps/chat/MSTeamsRule.py
@@ -1,6 +1,6 @@
+from dragonfly import ShortIntegerRef 
 from castervoice.lib.actions import Key, Text, Mouse
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from dragonfly import (AppContext, Choice, Dictation, Function, MappingRule,
                        Repeat)
@@ -108,7 +108,7 @@ class MSTeamsRule(MappingRule):
    }
     exported = True
     extras = [
-        IntegerRefST("nnavi10", 1, 11)
+        ShortIntegerRef("nnavi10", 1, 11)
     ]
     defaults = {
         "nnavi10": 1

--- a/castervoice/rules/apps/chat/webexteams.py
+++ b/castervoice/rules/apps/chat/webexteams.py
@@ -1,6 +1,6 @@
+from dragonfly import ShortIntegerRef 
 from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from dragonfly import (Dictation, MappingRule, Repeat)
 
@@ -102,7 +102,7 @@ class WebexTeamsRule(MappingRule):
     }
     exported = True
     extras = [
-        IntegerRefST("nnavi10", 1, 11),
+        ShortIntegerRef("nnavi10", 1, 11),
         Dictation("person"),
     ]
     defaults = {

--- a/castervoice/rules/apps/editor/atom.py
+++ b/castervoice/rules/apps/editor/atom.py
@@ -5,13 +5,12 @@ Official Site "https://atom.io/"
 """
 
 # How long to wait for the Atom palette to load before hitting the enter key
-from dragonfly import Pause, Function, Repeat, Dictation, Choice, MappingRule
+from dragonfly import Pause, Function, Repeat, Dictation, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Text, Key
 
 from castervoice.lib import settings, navigation
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 atom_palette_wait = 30
@@ -543,10 +542,10 @@ class AtomRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 50),
-        IntegerRefST("ln1", 1, 50000),
-        IntegerRefST("ln2", 1, 50000),
-        IntegerRefST("n2", 1, 10),
+        ShortIntegerRef("n", 1, 50),
+        ShortIntegerRef("ln1", 1, 50000),
+        ShortIntegerRef("ln2", 1, 50000),
+        ShortIntegerRef("n2", 1, 10),
         Choice("action", navigation.actions),
         Choice(
             "nrw", {

--- a/castervoice/rules/apps/editor/eclipse_rules/eclipse.py
+++ b/castervoice/rules/apps/editor/eclipse_rules/eclipse.py
@@ -1,4 +1,4 @@
-from dragonfly import Dictation, Function, Paste, Pause
+from dragonfly import Dictation, Function, Paste, Pause, ShortIntegerRef
 
 try: # Try first loading from caster user directory
     from eclipse_support import ec_con
@@ -8,7 +8,7 @@ except ImportError:
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.const import CCRType
-from castervoice.lib.merge.additions import IntegerRefST, Boolean
+from castervoice.lib.merge.additions import Boolean
 from castervoice.lib.merge.state.short import R
 
 from castervoice.lib.actions import Key, Text
@@ -39,7 +39,7 @@ class EclipseCCR(MergeRule):
     }
     extras = [
         Dictation("text"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
         Boolean("back"),
     ]
     defaults = {"n": 1, "back": False}

--- a/castervoice/rules/apps/editor/eclipse_rules/eclipse2.py
+++ b/castervoice/rules/apps/editor/eclipse_rules/eclipse2.py
@@ -1,4 +1,4 @@
-from dragonfly import Repeat, Dictation, Function, Choice, MappingRule
+from dragonfly import Repeat, Dictation, Function, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
@@ -8,7 +8,7 @@ except ImportError:
     from castervoice.rules.apps.editor.eclipse_rules.eclipse_support import ec_con
 
 from castervoice.rules.core.alphabet_rules import alphabet_support # Manually change import path if in user directory.
-from castervoice.lib.merge.additions import IntegerRefST, Boolean
+from castervoice.lib.merge.additions import Boolean
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 
@@ -78,7 +78,7 @@ class EclipseRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 3000),
+        ShortIntegerRef("n", 1, 3000),
         alphabet_support.get_alphabet_choice("a"),
         alphabet_support.get_alphabet_choice("b"),
         alphabet_support.get_alphabet_choice("c"),

--- a/castervoice/rules/apps/editor/emacs.py
+++ b/castervoice/rules/apps/editor/emacs.py
@@ -1,9 +1,8 @@
-from dragonfly import Dictation, MappingRule
+from dragonfly import Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -47,7 +46,7 @@ class EmacsRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1, "mim": ""}
 

--- a/castervoice/rules/apps/editor/flashdevelop.py
+++ b/castervoice/rules/apps/editor/flashdevelop.py
@@ -1,9 +1,8 @@
-from dragonfly import Repeat, Dictation, MappingRule, Pause
+from dragonfly import Repeat, Dictation, MappingRule, Pause, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -35,7 +34,7 @@ class FlashDevelopRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1, "mim": ""}
 

--- a/castervoice/rules/apps/editor/jetbrains.py
+++ b/castervoice/rules/apps/editor/jetbrains.py
@@ -1,8 +1,7 @@
-from dragonfly import Dictation, Repeat, MappingRule
+from dragonfly import Dictation, Repeat, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Text, Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 # Directional Movement
@@ -128,7 +127,7 @@ class JetbrainsRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
 
     defaults = {"n": 1, "mim": ""}

--- a/castervoice/rules/apps/editor/lyx.py
+++ b/castervoice/rules/apps/editor/lyx.py
@@ -1,7 +1,6 @@
-from dragonfly import Repeat, Choice, MappingRule
+from dragonfly import Repeat, Choice, MappingRule, ShortIntegerRef 
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -23,7 +22,7 @@ class LyxRule(MappingRule):
         "insert <environment>": R(Key("a-i, h, %(environment)s")),
         }
     extras = [
-        IntegerRefST("n", 1, 10),
+        ShortIntegerRef("n", 1, 10),
         Choice("environment", {
             "(in line formula | in line)": "i",
             "(display formula | display)": "d",

--- a/castervoice/rules/apps/editor/msvc.py
+++ b/castervoice/rules/apps/editor/msvc.py
@@ -1,7 +1,6 @@
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -31,7 +30,7 @@ class MSVCRule(MappingRule):
     }
     extras = [
         Dictation("text"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1}
 

--- a/castervoice/rules/apps/editor/notepadplusplus.py
+++ b/castervoice/rules/apps/editor/notepadplusplus.py
@@ -1,10 +1,9 @@
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text, Mouse
 
 from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -29,8 +28,8 @@ class NPPRule(MappingRule):
     }
     extras = [
         Dictation("text"),
-        IntegerRefST("n", 1, 1000),
-        IntegerRefST("n2", 1, 10),
+        ShortIntegerRef("n", 1, 1000),
+        ShortIntegerRef("n2", 1, 10),
     ]
     defaults = {"n": 1}
 

--- a/castervoice/rules/apps/editor/rstudio.py
+++ b/castervoice/rules/apps/editor/rstudio.py
@@ -1,11 +1,10 @@
-from dragonfly import Pause, Function, Choice, MappingRule
+from dragonfly import Pause, Function, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text, Mouse
 
 from castervoice.lib import navigation
 from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from castervoice.lib.temporary import Store, Retrieve
 
@@ -70,8 +69,8 @@ class RStudioRule(MappingRule):
 
     }
     extras = [
-        IntegerRefST("ln1", 1, 10000),
-        IntegerRefST("ln2", 1, 10000),
+        ShortIntegerRef("ln1", 1, 10000),
+        ShortIntegerRef("ln2", 1, 10000),
         Choice("action", navigation.actions),
     ]
     defaults = {"ln2": ""}

--- a/castervoice/rules/apps/editor/sqldeveloper.py
+++ b/castervoice/rules/apps/editor/sqldeveloper.py
@@ -1,9 +1,8 @@
-from dragonfly import Dictation, MappingRule
+from dragonfly import Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -16,7 +15,7 @@ class SQLDeveloperRule(MappingRule):
     }
     extras = [
         Dictation("text"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1}
 

--- a/castervoice/rules/apps/editor/ssms.py
+++ b/castervoice/rules/apps/editor/ssms.py
@@ -1,7 +1,6 @@
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -29,7 +28,7 @@ class SSMSRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1, "mim": ""}
 

--- a/castervoice/rules/apps/editor/sublime.py
+++ b/castervoice/rules/apps/editor/sublime.py
@@ -1,9 +1,8 @@
-from dragonfly import Function, Dictation, Choice, MappingRule,Repeat
+from dragonfly import Function, Dictation, Choice, MappingRule, Repeat, ShortIntegerRef
 
 from castervoice.lib import navigation
 from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from castervoice.lib.temporary import Store, Retrieve
 
@@ -182,10 +181,10 @@ class SublimeRule(MappingRule):
     }
     extras = [
         Dictation("dict"),
-        IntegerRefST("ln1", 1, 1000),
-        IntegerRefST("ln2", 1, 1000),
-        IntegerRefST("n2", 1, 9),
-        IntegerRefST("n3", 1, 21),
+        ShortIntegerRef("ln1", 1, 1000),
+        ShortIntegerRef("ln2", 1, 1000),
+        ShortIntegerRef("n2", 1, 9),
+        ShortIntegerRef("n3", 1, 21),
         Choice("action", navigation.actions),
         Choice(
             "nth", {

--- a/castervoice/rules/apps/editor/typora.py
+++ b/castervoice/rules/apps/editor/typora.py
@@ -3,11 +3,10 @@ __author__ = 'LexiconCode'
 Command-module for Typora
 Official Site "https://typora.io/"
 """
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -77,8 +76,8 @@ class TyporaRule(MappingRule):
 
     extras = [
         Dictation("text"),
-        IntegerRefST("h", 0, 6),
-        IntegerRefST("n", 1, 30),
+        ShortIntegerRef("h", 0, 6),
+        ShortIntegerRef("n", 1, 30),
     ]
 
     defaults = {"n": 1, "h": 1}

--- a/castervoice/rules/apps/editor/unity.py
+++ b/castervoice/rules/apps/editor/unity.py
@@ -1,6 +1,5 @@
-from dragonfly import Key,MappingRule, Dictation, Choice,Text
+from dragonfly import Key, MappingRule, Dictation, Choice, Text, IntegerRef
 from castervoice.lib.merge.state.short import R
-from castervoice.lib.merge.additions import IntegerRef
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 
 class UnityRule(MappingRule):

--- a/castervoice/rules/apps/editor/visualstudio.py
+++ b/castervoice/rules/apps/editor/visualstudio.py
@@ -1,9 +1,8 @@
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 
 
 from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -91,7 +90,7 @@ class VisualStudioRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1, "mim": ""}
 

--- a/castervoice/rules/apps/editor/vscode_rules/vscode.py
+++ b/castervoice/rules/apps/editor/vscode_rules/vscode.py
@@ -1,11 +1,10 @@
 # thanks to Casper for contributing commands to this.
-from dragonfly import Repeat, Dictation, Choice
+from dragonfly import Repeat, Dictation, Choice, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -127,8 +126,8 @@ class VSCodeCcrRule(MergeRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 100),
-        IntegerRefST("m", 1, 10),
+        ShortIntegerRef("n", 1, 100),
+        ShortIntegerRef("m", 1, 10),
         Choice(
             "between_parables", {
                 "prekris": "lparen",

--- a/castervoice/rules/apps/editor/vscode_rules/vscode2.py
+++ b/castervoice/rules/apps/editor/vscode_rules/vscode2.py
@@ -1,11 +1,10 @@
-from dragonfly import Function, Repeat, Choice, Dictation, MappingRule, Pause
+from dragonfly import Function, Repeat, Choice, Dictation, MappingRule, Pause, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Mouse
 
 from castervoice.lib import navigation
 from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -290,9 +289,9 @@ class VSCodeNonCcrRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("ln1", 1, 1000),
-        IntegerRefST("ln2", 1, 1000),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("ln1", 1, 1000),
+        ShortIntegerRef("ln2", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
         Choice("action", navigation.actions),
         Choice(
             "nth", {

--- a/castervoice/rules/apps/file_manager/fman.py
+++ b/castervoice/rules/apps/file_manager/fman.py
@@ -1,9 +1,8 @@
-from dragonfly import Pause, Choice, MappingRule
+from dragonfly import Pause, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -38,7 +37,7 @@ class fmanRule(MappingRule):
         "command pallette": R(Key("cs-p")),
     }
     extras = [
-        IntegerRefST("num", 1, 4),
+        ShortIntegerRef("num", 1, 4),
         Choice("fav", {
             "example favourite": "ef",
         }),

--- a/castervoice/rules/apps/git_clients/githubdesktop.py
+++ b/castervoice/rules/apps/git_clients/githubdesktop.py
@@ -1,9 +1,8 @@
-from dragonfly import Repeat, MappingRule
+from dragonfly import Repeat, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -43,7 +42,7 @@ class GitHubDeskRule(MappingRule):
         "[create] pull request": R(Key("c-r")),
     }
     extras = [
-        IntegerRefST("n", 1, 10),
+        ShortIntegerRef("n", 1, 10),
     ]
     defaults = {"n": 1}
 

--- a/castervoice/rules/apps/git_clients/kdiff3.py
+++ b/castervoice/rules/apps/git_clients/kdiff3.py
@@ -1,7 +1,6 @@
-from dragonfly import Dictation, MappingRule
+from dragonfly import Dictation, MappingRule, ShortIntegerRef
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -12,7 +11,7 @@ class KDiff3Rule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1, "mim": ""}
 

--- a/castervoice/rules/apps/microsoft_office/excel.py
+++ b/castervoice/rules/apps/microsoft_office/excel.py
@@ -7,12 +7,11 @@ Alex Boche 2019
 
 # this function takes a dictionary and returns a dictionary whose keys are sequences of keys of the original dictionary
 # and whose values our the corresponding sequences of values of the original dictionary
-from dragonfly import Repeat, Dictation, Choice, MappingRule, Repetition
+from dragonfly import Repeat, Dictation, Choice, MappingRule, Repetition, ShortIntegerRef
 
 from castervoice.rules.core.alphabet_rules import alphabet_support  # Manually change in port in if in user directory
 from castervoice.lib.actions import Text, Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 class ExcelRule(MappingRule):
@@ -89,9 +88,9 @@ class ExcelRule(MappingRule):
     }
     extras = [
         Dictation("dict"),
-        IntegerRefST("n", 1, 10),
-        IntegerRefST("row_1", 1, 100),
-        IntegerRefST("row_2", 1, 100),
+        ShortIntegerRef("n", 1, 10),
+        ShortIntegerRef("row_1", 1, 100),
+        ShortIntegerRef("row_2", 1, 100),
         # change max to 3 if you want sequences of lentgh three and so on
         Repetition(Choice("alphabet1", alphabet_support.caster_alphabet()), min=1, max=2, name="column_1"),
         Repetition(Choice("alphabet2", alphabet_support.caster_alphabet()), min=1, max=2, name="column_2")

--- a/castervoice/rules/apps/microsoft_office/outlook.py
+++ b/castervoice/rules/apps/microsoft_office/outlook.py
@@ -1,8 +1,7 @@
-from dragonfly import Function, Repeat, Dictation, Choice, MappingRule
+from dragonfly import Function, Repeat, Dictation, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -112,7 +111,7 @@ class OutlookRule(MappingRule):
     extras = [
         Dictation("dict"),
         Dictation("text"),
-        IntegerRefST("n", 1, 100),
+        ShortIntegerRef("n", 1, 100),
         Choice(
             "sort_by", {
                 "date": "d",

--- a/castervoice/rules/apps/mouse_grids/griddouglas.py
+++ b/castervoice/rules/apps/mouse_grids/griddouglas.py
@@ -1,10 +1,9 @@
 import time
-from dragonfly import Function, Choice, MappingRule
+from dragonfly import Function, Choice, MappingRule, ShortIntegerRef
 from dragonfly.actions.mouse import get_cursor_position
 from castervoice.lib import control, navigation
 from castervoice.lib.actions import Mouse
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from castervoice.rules.ccr.standard import SymbolSpecs
 
@@ -86,12 +85,12 @@ class DouglasGridRule(MappingRule):
             R(Function(kill)),
     }
     extras = [
-        IntegerRefST("x", 0, 300),
-        IntegerRefST("y", 0, 300),
-        IntegerRefST("x1", 0, 300),
-        IntegerRefST("y1", 0, 300),
-        IntegerRefST("x2", 0, 300),
-        IntegerRefST("y2", 0, 300),
+        ShortIntegerRef("x", 0, 300),
+        ShortIntegerRef("y", 0, 300),
+        ShortIntegerRef("x1", 0, 300),
+        ShortIntegerRef("y1", 0, 300),
+        ShortIntegerRef("x2", 0, 300),
+        ShortIntegerRef("y2", 0, 300),
         Choice("action", {
             "kick": 0,
             "psychic": 1,

--- a/castervoice/rules/apps/mouse_grids/gridlegion.py
+++ b/castervoice/rules/apps/mouse_grids/gridlegion.py
@@ -1,8 +1,7 @@
 import time
-from dragonfly import Function, Choice, MappingRule, Mouse
+from dragonfly import Function, Choice, MappingRule, Mouse, ShortIntegerRef
 from castervoice.lib import control, navigation
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from castervoice.rules.ccr.standard import SymbolSpecs
 
@@ -77,9 +76,9 @@ class LegionGridRule(MappingRule):
             "psychic": 1,
             "select | light": 2,
         }),
-        IntegerRefST("n", 0, 1000),
-        IntegerRefST("n1", 0, 1000),
-        IntegerRefST("n2", 0, 1000),
+        ShortIntegerRef("n", 0, 1000),
+        ShortIntegerRef("n1", 0, 1000),
+        ShortIntegerRef("n2", 0, 1000),
     ]
     defaults = {
         "action": -1,

--- a/castervoice/rules/apps/mouse_grids/gridrainbow.py
+++ b/castervoice/rules/apps/mouse_grids/gridrainbow.py
@@ -1,10 +1,9 @@
 import time
-from dragonfly import Function, Choice, MappingRule
+from dragonfly import Function, Choice, MappingRule, ShortIntegerRef
 from dragonfly.actions.mouse import get_cursor_position
 from castervoice.lib import control, navigation
 from castervoice.lib.actions import Mouse
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from castervoice.rules.ccr.standard import SymbolSpecs
 
@@ -88,9 +87,9 @@ class RainbowGridRule(MappingRule):
             R(Function(kill)),
     }
     extras = [
-        IntegerRefST("pre", 0, 9),
-        IntegerRefST("pre1", 0, 9),
-        IntegerRefST("pre2", 0, 9),
+        ShortIntegerRef("pre", 0, 9),
+        ShortIntegerRef("pre1", 0, 9),
+        ShortIntegerRef("pre2", 0, 9),
         Choice(
             "color", {
                 "(red | rot)": 0,
@@ -118,9 +117,9 @@ class RainbowGridRule(MappingRule):
                 "(blue | blau)": 4,
                 "(purple | lila)": 5
             }),
-        IntegerRefST("n", 0, 100),
-        IntegerRefST("n1", 0, 100),
-        IntegerRefST("n2", 0, 100),
+        ShortIntegerRef("n", 0, 100),
+        ShortIntegerRef("n1", 0, 100),
+        ShortIntegerRef("n2", 0, 100),
         Choice("action", {
             "kick": 0,
             "psychic": 1,

--- a/castervoice/rules/apps/mouse_grids/gridsudoku.py
+++ b/castervoice/rules/apps/mouse_grids/gridsudoku.py
@@ -1,9 +1,8 @@
 import time
-from dragonfly import Function, Choice, MappingRule
+from dragonfly import Function, Choice, MappingRule, ShortIntegerRef
 from castervoice.lib import control, navigation
 from castervoice.lib.actions import Mouse
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 from castervoice.rules.ccr.standard import SymbolSpecs
 
@@ -81,10 +80,10 @@ class SudokuGridRule(MappingRule):
             R(Function(kill)),
     }
     extras = [
-        IntegerRefST("n", -1, 1500),
-        IntegerRefST("n0", -1, 1500),
-        IntegerRefST("s", 0, 10),
-        IntegerRefST("s0", 0, 10),
+        ShortIntegerRef("n", -1, 1500),
+        ShortIntegerRef("n0", -1, 1500),
+        ShortIntegerRef("s", 0, 10),
+        ShortIntegerRef("s0", 0, 10),
         Choice("action", {
             "move": 0,
             "kick": 1,

--- a/castervoice/rules/apps/pdf/adobe_acrobat.py
+++ b/castervoice/rules/apps/pdf/adobe_acrobat.py
@@ -1,7 +1,6 @@
-from dragonfly import Dictation, Repeat, Pause, MappingRule
+from dragonfly import Dictation, Repeat, Pause, MappingRule, ShortIntegerRef
 from castervoice.lib.actions import Text, Key, Mouse
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 _SHOW_HIDE_MENU = Key("a-v, s")
@@ -98,9 +97,9 @@ class AcrobatRule(MappingRule):
     }
     extras = [
         Dictation("dict"),
-        IntegerRefST("n", 1, 1000),
-        IntegerRefST("m", 1, 9),
-        IntegerRefST("speed_one_to_nine", 1, 9),
+        ShortIntegerRef("n", 1, 1000),
+        ShortIntegerRef("m", 1, 9),
+        ShortIntegerRef("speed_one_to_nine", 1, 9),
     ]
     defaults = {"n": 1, "dict": "nothing"}
 

--- a/castervoice/rules/apps/pdf/foxitreader.py
+++ b/castervoice/rules/apps/pdf/foxitreader.py
@@ -1,9 +1,8 @@
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -16,7 +15,7 @@ class FoxitRule(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1, "mim": ""}
 

--- a/castervoice/rules/apps/speech_engine/dragon_rules/dragon_support.py
+++ b/castervoice/rules/apps/speech_engine/dragon_rules/dragon_support.py
@@ -1,8 +1,7 @@
-from dragonfly import Dictation, Choice
+from dragonfly import Dictation, Choice, ShortIntegerRef
 
 from castervoice.lib import utilities
 from castervoice.lib.actions import Text, Key
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.util import recognition_history
 
 _DBL_FIX_HISTORY = recognition_history.get_and_register_history(1)
@@ -20,7 +19,7 @@ def fix_dragon_double():
 def extras_for_whole_file():
     return [
         Dictation("text"),
-        IntegerRefST("n10", 1, 10),
+        ShortIntegerRef("n10", 1, 10),
         Choice("first_second_third", {
             "first": 0,
             "second": 1,

--- a/castervoice/rules/apps/terminal/gitbash.py
+++ b/castervoice/rules/apps/terminal/gitbash.py
@@ -1,9 +1,8 @@
-from dragonfly import Mimic, Function, MappingRule
+from dragonfly import Mimic, Function, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -102,7 +101,7 @@ class GitBashRule(MappingRule):
             R(Text(" > FILENAME")),
     }
     extras = [
-        IntegerRefST("n", 1, 10000),
+        ShortIntegerRef("n", 1, 10000),
     ]
     defaults = {"n": 0}
 

--- a/castervoice/rules/apps/windows_os/explorer.py
+++ b/castervoice/rules/apps/windows_os/explorer.py
@@ -1,9 +1,8 @@
-from dragonfly import Dictation, MappingRule
+from dragonfly import Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -37,7 +36,7 @@ class IERule(MappingRule):
     }
     extras = [
         Dictation("text"),
-        IntegerRefST("n", 1, 1000),
+        ShortIntegerRef("n", 1, 1000),
     ]
     defaults = {"n": 1}
 

--- a/castervoice/rules/apps/windows_os/file_dialogue.py
+++ b/castervoice/rules/apps/windows_os/file_dialogue.py
@@ -1,10 +1,9 @@
-from dragonfly import Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 
 from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -22,7 +21,7 @@ class FileDialogueRule(MappingRule):
         "file type": R(Key("c-l, tab:7")),
 
     }
-    extras = [IntegerRefST("n", 1, 10), Dictation("text")]
+    extras = [ShortIntegerRef("n", 1, 10), Dictation("text")]
     defaults = {
         "n": 1,
     }

--- a/castervoice/rules/apps/windows_os/winword.py
+++ b/castervoice/rules/apps/windows_os/winword.py
@@ -1,7 +1,6 @@
-from dragonfly import Dictation, MappingRule
+from dragonfly import Dictation, MappingRule, ShortIntegerRef
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -11,7 +10,7 @@ class MSWordRule(MappingRule):
     }
     extras = [
         Dictation("dict"),
-        IntegerRefST("n", 1, 100),
+        ShortIntegerRef("n", 1, 100),
     ]
     defaults = {"n": 1, "dict": "nothing"}
 

--- a/castervoice/rules/ccr/css_rules/css.py
+++ b/castervoice/rules/ccr/css_rules/css.py
@@ -1,9 +1,9 @@
+from dragonfly import ShortIntegerRef
 from castervoice.lib.actions import Key, Text
 from castervoice.lib import settings, printer
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.context import AppContext
-from castervoice.lib.merge.additions import IntegerRefST
 
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
@@ -419,7 +419,7 @@ class CSS(MergeRule):
 
     }
     extras = [
-        IntegerRefST("ln1", 1, 1000),
+        ShortIntegerRef("ln1", 1, 1000),
     ]
     defaults = {}
 

--- a/castervoice/rules/ccr/markdown_rules/markdown.py
+++ b/castervoice/rules/ccr/markdown_rules/markdown.py
@@ -1,9 +1,8 @@
-from dragonfly import Function, Dictation, Choice
+from dragonfly import Function, Dictation, Choice, ShortIntegerRef
 
 from castervoice.lib.actions import Text, Key
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 from castervoice.lib.temporary import Store, Retrieve
@@ -28,8 +27,8 @@ class Markdown(MergeRule):
     }
     extras = [
         Dictation("dict"),
-        IntegerRefST("n", 1, 12),
-        IntegerRefST("num", 1, 7),
+        ShortIntegerRef("n", 1, 12),
+        ShortIntegerRef("num", 1, 7),
         Choice(
             "element", {
                 "list": "asterisk, space",

--- a/castervoice/rules/ccr/recording_rules/again.py
+++ b/castervoice/rules/ccr/recording_rules/again.py
@@ -8,8 +8,6 @@ from castervoice.lib.util import recognition_history
 
 _history = recognition_history.get_and_register_history(10)
 
-#TODO: Investigate why Caster's abstraction of dragonflys `ShortIntegerRef` Via `IntegerRefST` causes recognition errors in this grammar.
-
 class Again(MappingRule):
 
     mapping = {

--- a/castervoice/rules/ccr/rust_rules/rust.py
+++ b/castervoice/rules/ccr/rust_rules/rust.py
@@ -1,11 +1,10 @@
-from dragonfly import Choice
+from dragonfly import Choice, ShortIntegerRef
 
 from castervoice.rules.core.alphabet_rules import alphabet_support # Manually change import path if in user directory.
 from castervoice.lib.actions import Text, Key
 from castervoice.rules.ccr.standard import SymbolSpecs
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -136,7 +135,7 @@ class Rust(MergeRule):
         }),
         Choice("signed", {"unsigned": "u"}),
         Choice("mutability", {"mute ah | mute": "mut "}),
-        IntegerRefST("n", 0, 1000),
+        ShortIntegerRef("n", 0, 1000),
         alphabet_support.get_alphabet_choice("a"),
         alphabet_support.get_alphabet_choice("b"),
     ]

--- a/castervoice/rules/ccr/vhdl_rules/vhdl.py
+++ b/castervoice/rules/ccr/vhdl_rules/vhdl.py
@@ -3,13 +3,12 @@ Created on 18 Mar 2018
 
 @author: gerrish
 '''
-from dragonfly import Function, Choice
+from dragonfly import Function, Choice, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 from castervoice.rules.ccr.standard import SymbolSpecs
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -105,12 +104,12 @@ class VHDL(MergeRule):
     }
 
     extras = [
-        IntegerRefST("amount", 1, 128),
+        ShortIntegerRef("amount", 1, 128),
         Choice("digit", {
             "(zero|zeros)": 0,
             "(one|once)": 1
         }),
-        IntegerRefST("digit", 0, 2)
+        ShortIntegerRef("digit", 0, 2)
     ]
     defaults = {}
 

--- a/castervoice/rules/ccr/voice_dev_commands_rules/voice_dev_commands.py
+++ b/castervoice/rules/ccr/voice_dev_commands_rules/voice_dev_commands.py
@@ -5,14 +5,13 @@ users may want to make this context-specific to their text editors
 '''
 import copy
 
-from dragonfly import Pause, Choice, Dictation, Function
+from dragonfly import Pause, Choice, Dictation, Function, ShortIntegerRef
 from dragonfly.actions.action_mouse import get_cursor_position
 
 from castervoice.lib.actions import Text, Key
 from castervoice.rules.core.keyboard_rules.keyboard import Keyboard
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -216,8 +215,8 @@ class VoiceDevCommands(MergeRule):
             "up": "up",
             "down": "down",
         }),
-        IntegerRefST("distance_1", 1, 500),
-        IntegerRefST("distance_2", 1, 500),
+        ShortIntegerRef("distance_1", 1, 500),
+        ShortIntegerRef("distance_2", 1, 500),
     ]
     defaults = {"spec": "", "dict": "", "text": "", "mouse_button": ""}
 

--- a/castervoice/rules/core/keyboard_rules/keyboard.py
+++ b/castervoice/rules/core/keyboard_rules/keyboard.py
@@ -1,7 +1,16 @@
 from dragonfly import Function, Repeat, Dictation, Choice, ContextAction, MappingRule, ShortIntegerRef
 from castervoice.lib.context import AppContext
 
-from castervoice.rules.core.keyboard_rules import keyboard_support
+try:  # Try first loading from caster user directory
+    from keyboard_rules import keyboard_support
+except ImportError:
+    from castervoice.rules.core.keyboard_rules import keyboard_support
+
+try:  # Try first loading from caster user directory
+    from punctuation_rules import punctuation_support
+except ImportError:
+    from castervoice.rules.core.punctuation_rules import punctuation_support
+
 from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
@@ -10,9 +19,7 @@ from castervoice.lib.merge.state.actions import AsynchronousAction, ContextSeeke
 from castervoice.lib.merge.state.actions2 import UntilCancelled
 from castervoice.lib.merge.state.short import S, L, R
 
-_tpd = text_punc_dict()
-
-cat_spec_and_reverse = lambda s1, s2: "(" + s1 + " " + s2 + ")" + " | " + "(" + s2 + " " + s1 + ")"
+_tpd = punctuation_support.text_punc_dict()
 
 def hold_keys(modifier_choice_key_name):
     modifier_list = modifier_choice_key_name.strip().split(" ")

--- a/castervoice/rules/core/keyboard_rules/keyboard.py
+++ b/castervoice/rules/core/keyboard_rules/keyboard.py
@@ -1,4 +1,4 @@
-from dragonfly import Function, Repeat, Dictation, Choice, ContextAction, MappingRule
+from dragonfly import Function, Repeat, Dictation, Choice, ContextAction, MappingRule, ShortIntegerRef
 from castervoice.lib.context import AppContext
 
 from castervoice.lib import navigation, context, textformat, text_utils
@@ -20,7 +20,6 @@ except ImportError:
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.actions import AsynchronousAction, ContextSeeker
 from castervoice.lib.merge.state.actions2 import UntilCancelled

--- a/castervoice/rules/core/navigation_rules/nav.py
+++ b/castervoice/rules/core/navigation_rules/nav.py
@@ -1,4 +1,4 @@
-from dragonfly import Function, Repeat, Dictation, Choice, ContextAction
+from dragonfly import Function, Repeat, Dictation, Choice, ContextAction, ShortIntegerRef
 from castervoice.lib.context import AppContext
 
 from castervoice.lib import navigation, context, textformat, text_utils
@@ -26,7 +26,6 @@ except ImportError:
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.actions import AsynchronousAction, ContextSeeker
 from castervoice.lib.merge.state.actions2 import UntilCancelled
@@ -208,10 +207,10 @@ class Navigation(MergeRule):
             ]
     }    
     extras = [
-        IntegerRefST("nnavi10", 1, 11),
-        IntegerRefST("nnavi3", 1, 4),
-        IntegerRefST("nnavi50", 1, 50),
-        IntegerRefST("nnavi500", 1, 500),
+        ShortIntegerRef("nnavi10", 1, 11),
+        ShortIntegerRef("nnavi3", 1, 4),
+        ShortIntegerRef("nnavi50", 1, 50),
+        ShortIntegerRef("nnavi500", 1, 500),
         Dictation("textnv"),
         Choice("enclosure", _dtpd),
         

--- a/castervoice/rules/core/navigation_rules/nav2.py
+++ b/castervoice/rules/core/navigation_rules/nav2.py
@@ -1,4 +1,4 @@
-from dragonfly import Function, Repeat, Dictation, Choice, MappingRule
+from dragonfly import Function, Repeat, Dictation, Choice, MappingRule, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Mouse
 from castervoice.lib import navigation, utilities
@@ -10,7 +10,6 @@ except ImportError:
     from castervoice.rules.core.alphabet_rules import alphabet_support
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.actions import AsynchronousAction
 from castervoice.lib.merge.state.short import S, L, R
 
@@ -105,9 +104,9 @@ class NavigationNon(MappingRule):
     extras = [
         Dictation("text"),
         Dictation("mim"),
-        IntegerRefST("function_key", 1, 13),
-        IntegerRefST("n", 1, 50),
-        IntegerRefST("nnavi500", 1, 500),
+        ShortIntegerRef("function_key", 1, 13),
+        ShortIntegerRef("n", 1, 50),
+        ShortIntegerRef("nnavi500", 1, 500),
         Choice("time_in_seconds", {
             "super slow": 5,
             "slow": 2,

--- a/castervoice/rules/core/navigation_rules/window_mgmt_rule.py
+++ b/castervoice/rules/core/navigation_rules/window_mgmt_rule.py
@@ -1,8 +1,7 @@
-from dragonfly import MappingRule, Function, Repeat
+from dragonfly import MappingRule, Function, Repeat, ShortIntegerRef
 
 from castervoice.lib import utilities
 from castervoice.lib import virtual_desktops
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
@@ -38,7 +37,7 @@ class WindowManagementRule(MappingRule):
     }
 
     extras = [
-        IntegerRefST("n", 1, 20, default=1),
+        ShortIntegerRef("n", 1, 20, default=1),
     ]
 
 

--- a/castervoice/rules/core/numbers_rules/numeric.py
+++ b/castervoice/rules/core/numbers_rules/numeric.py
@@ -1,4 +1,4 @@
-from dragonfly import Choice, Function
+from dragonfly import Choice, Function, ShortIntegerRef
 
 try:  # Try first loading from caster user directory
     from numeric_support import word_number, numbers2
@@ -8,7 +8,6 @@ except ImportError:
 from castervoice.lib.actions import Text
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -24,8 +23,8 @@ class Numbers(MergeRule):
     }
 
     extras = [
-        IntegerRefST("wn", 0, 10),
-        IntegerRefST("wnKK", 0, 1000000),
+        ShortIntegerRef("wn", 0, 10),
+        ShortIntegerRef("wnKK", 0, 1000000),
         Choice(
             "long", {
                 "long": " ",

--- a/castervoice/rules/core/numbers_rules/numeric_support.py
+++ b/castervoice/rules/core/numbers_rules/numeric_support.py
@@ -1,4 +1,3 @@
-from castervoice.lib import settings
 from castervoice.lib.actions import Text
 
 def word_number(wn):
@@ -15,25 +14,6 @@ def word_number(wn):
         9: "nine"
     }
     Text(numbers_to_words[int(wn)]).execute()
-
-
-def numbers_list_1_to_9():
-    result = ["one", "torque", "traio", "fairn", "faif", "six", "seven", "eigen", "nine"]
-    if not settings.SETTINGS["miscellaneous"]["integer_remap_opt_in"]:
-        result[1] = "two"
-        result[2] = "three"
-        result[3] = "four"
-        result[4] = "five"
-        result[7] = "eight"
-    return result
-
-
-def numbers_map_1_to_9():
-    result = {}
-    l = numbers_list_1_to_9()
-    for i in range(0, len(l)):
-        result[l[i]] = i + 1
-    return result
 
 
 def numbers2(wnKK):

--- a/castervoice/rules/core/punctuation_rules/punctuation.py
+++ b/castervoice/rules/core/punctuation_rules/punctuation.py
@@ -1,4 +1,4 @@
-from dragonfly import Choice, Repeat
+from dragonfly import Choice, Repeat, ShortIntegerRef
 
 from castervoice.lib.actions import Key, Text
 
@@ -9,7 +9,6 @@ except ImportError:
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -38,8 +37,8 @@ class Punctuation(MergeRule):
     }
 
     extras = [
-        IntegerRefST("npunc", 0, 10),
-        IntegerRefST("npunc100", 0, 100),
+        ShortIntegerRef("npunc", 0, 10),
+        ShortIntegerRef("npunc100", 0, 100),
         Choice(
             "long", {
                 "long": " ",

--- a/castervoice/rules/core/text_manipulation_rules/text_manipulation.py
+++ b/castervoice/rules/core/text_manipulation_rules/text_manipulation.py
@@ -1,4 +1,4 @@
-from dragonfly import Function, Choice, Repetition, Dictation
+from dragonfly import Function, Choice, Repetition, Dictation, ShortIntegerRef
 
 try:  # Try first loading from caster user directory
     from text_manipulation_rules import text_manipulation_support
@@ -17,7 +17,6 @@ except ImportError:
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
 
@@ -140,10 +139,10 @@ class TextManipulation(MergeRule):
         Dictation("dictation"),
         Dictation("dictation2"),
         Dictation("text"),
-        IntegerRefST("n", 1, 100),
-        IntegerRefST("m", 1, 100),
-        IntegerRefST("wait_time", 1, 1000),
-        IntegerRefST("number_of_lines_to_search", 1, 50),
+        ShortIntegerRef("n", 1, 100),
+        ShortIntegerRef("m", 1, 100),
+        ShortIntegerRef("wait_time", 1, 1000),
+        ShortIntegerRef("number_of_lines_to_search", 1, 50),
 
 
         Choice("character", character_dict),

--- a/castervoice/rules/core/utility_rules/hardware_rule.py
+++ b/castervoice/rules/core/utility_rules/hardware_rule.py
@@ -1,9 +1,8 @@
-from dragonfly import MappingRule, Playback, Function, Pause, Choice, Repeat
+from dragonfly import MappingRule, Playback, Function, Pause, Choice, Repeat, ShortIntegerRef
 
 from castervoice.lib.actions import Key
 from castervoice.lib import settings
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -27,8 +26,8 @@ class HardwareRule(MappingRule):
             R(Key("w-p") + Pause("100") + Function(change_monitor))
     }
     extras = [
-        IntegerRefST("n_media", 1, 15),
-        IntegerRefST("n_volume", 1, 50),
+        ShortIntegerRef("n_media", 1, 15),
+        ShortIntegerRef("n_volume", 1, 50),
         Choice("multimedia_control", {
             "next": "tracknext",
             "back":"trackprev",

--- a/castervoice/rules/core/utility_rules/mouse_alts_rules.py
+++ b/castervoice/rules/core/utility_rules/mouse_alts_rules.py
@@ -1,7 +1,6 @@
-from dragonfly import MappingRule, Function, Choice
+from dragonfly import MappingRule, Function, Choice, ShortIntegerRef
 from castervoice.lib import navigation, utilities
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
-from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R
 
 
@@ -21,7 +20,7 @@ class MouseAlternativesRule(MappingRule):
                 Function(utilities.focus_mousegrid, gridtitle="sudokugrid")),
     }
     extras = [
-        IntegerRefST("monitor", 1, 10),
+        ShortIntegerRef("monitor", 1, 10),
         Choice("rough", {
             "rough": True,
             "detailed": False

--- a/docs/readthedocs/Caster_Settings/settings.md
+++ b/docs/readthedocs/Caster_Settings/settings.md
@@ -69,13 +69,10 @@ ccr_on = true # Toggle on and off all CCR commands regardless of grammar.
 dev_commands = true # No longer used
 history_playback_delay_secs = 1.0 # How fast the `playback` command replays from 'record from history'
 hmc = true # Turns off GUI components of Caster
-integer_remap_crash_fix = false # Unknown
-integer_remap_opt_in = false # Unknown
 keypress_wait = 50 # Configurable keypress outer pause wait from dragonfly
 legion_vertical_columns = 30 # How many vertical lines are in the Legion MouseGrid
 max_ccr_repetitions = 16 # How many CCR commands can uttered in a row. Affects grammar complexity
 print_rdescripts = true # Prints out commands to the status window after dictation
-short_integer_opt_out = false # Unknown
 status_window_foreground_on_error = false # If Caster logs an error, the status window will appear for end user to evaluate error message
 use_aenea = false # Enables aenea third-party integration
 

--- a/docs/readthedocs/Rule_Construction/Advanced_Caster_Rules/ContextStack.md
+++ b/docs/readthedocs/Rule_Construction/Advanced_Caster_Rules/ContextStack.md
@@ -114,7 +114,7 @@ AsynchronousAction optional parameters:
 - `rdescript` - same as RegisteredAction
 - `blocking` - does it block other context stack actions until it completes
 
-AsynchronousAction also has the special property that you can use `time_in_seconds` and `repetitions` as IntegerRefST extras in the spec, and they will override the defaults or whatever is set in the constructor.
+AsynchronousAction also has the special property that you can use `time_in_seconds` and `repetitions` as ShortIntegerRef extras in the spec, and they will override the defaults or whatever is set in the constructor.
 
 Example AsynchronousActions:
 

--- a/docs/readthedocs/Rule_Construction/Advanced_Caster_Rules/NodeRule.md
+++ b/docs/readthedocs/Rule_Construction/Advanced_Caster_Rules/NodeRule.md
@@ -66,7 +66,7 @@ Some further explanation:
 - `spec` - the same sort of spec you would use in a Dragonfly MappingRule
 - `SomeDragonflyAction` - Text, Mimic, Key, etc.
 - `<child nodes>` - a list of HintNodes, which may themselves have child nodes, etc.
-- `<extras>` - a list of Dragonfly extras, the same kind you would use in a MappingRule (IntegerRefST, Dictation, Choice, etc.)
+- `<extras>` - a list of Dragonfly extras, the same kind you would use in a MappingRule (ShortIntegerRef, Dictation, Choice, etc.)
 - `<defaults>` - a dict of default values for the extras, again, the same kind you would use in a MappingRule
 
 A few examples:

--- a/docs/readthedocs/Rule_Construction/Taxonomy_of_a_Rule.md
+++ b/docs/readthedocs/Rule_Construction/Taxonomy_of_a_Rule.md
@@ -7,6 +7,6 @@ Throughout the Caster documentation, you will see references to `rule`, `command
 - `spec` : This is what you say in order to invoke an `action`.
 - `action` : This is what happens when you speak a `spec`. Examples include Dragonfly's [Key](http://dragonfly.readthedocs.io/en/latest/actions.html#key-action), Text, and Function actions, or Caster's [R](http://caster.readthedocs.io/en/latest/caster/doc/readthedocs/ContextStack/#registeredaction), [ContextSeeker](http://caster.readthedocs.io/en/latest/caster/doc/readthedocs/ContextStack/#contextseeker), or [AsynchronousAction](http://caster.readthedocs.io/en/latest/caster/doc/readthedocs/ContextStack/#asynchronousaction) actions.
 - `command` : The combination of a `spec` and an `action`. In MappingRules or MergeRules, these are key/value pairs.
-- `extra` : A sub-component of a `spec`. Examples include Dragonfly's Dictation, IntegerRef, and Choice, or Caster's IntegerRefST and Boolean.
+- `extra` : A sub-component of a `spec`. Examples include Dragonfly's Dictation, IntegerRef, and Choice, or Caster's Boolean.
 - `default` : A default value for an `extra`. Optional `extra`s in a `spec` should have default values.
 - `rule` : Any of the classes which extend Dragonfly's Rule class, but most commonly, MappingRule and MergeRule.


### PR DESCRIPTION
## Description
Remove integer_remap_crash_fix and integer_remap
ShortIntegerRef as IntegerRefST compatibility shim
## Related Issue

https://github.com/dictation-toolbox/Caster/issues/857 Unable to dictate 5 consecutive numbers 
IntegerRefST has caused issues with `again do` command

## Motivation and Context

IntegerRefST was originally used for integer_remap_crash_fix and integer_remap
integer_remap allowed you to remap some integers names to your own preference.
However this feature has not been used my knowledge by anyone since my time utilizing caster over 6 years. 
It's caused a number of bugs both with numerics and `again do` grammar hence its removal.


## How Has This Been Tested

A compatibility variable was left within `from castervoice.lib.merge.additions` renaming `ShortIntegerRef` as `IntegerRefST`. This allows end-user grammars that may be relying on `IntegerRefST` to have compatibility with `ShortIntegerRef` without breaking their grammar.

if ShortIntegerRef is imported than a warning message will appear to the end-user to migrate their imports.

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [x] New documentation is clear and complete.
- [x] Code is clear and readable.
