### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     name="castervoice",
     version=find_version("castervoice/lib", "version.py"),
     author="synkarius",
-    author_email="dconway1985@gmail.com",
+    author_email="caster@donotrackplus.com",
     description="Dragonfly-Based Voice Programming Toolkit",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     name="castervoice",
     version=find_version("castervoice/lib", "version.py"),
     author="synkarius",
-    author_email="caster@donotrackplus.com",
+    author_email="CasterVoice@protonmail.com",
     description="Dragonfly-Based Voice Programming Toolkit",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description

Remove my old email from setup.py. The replacement, "caster@donottrackplus.com", forwards to my new email. Ideally, this should be changed to be Dictation Toolbox's email, or that of a current maintainer.

## Motivation and Context

This old email is now incorrect.

## Checklist

- [ ] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
