### PR TITLE
Pin pyvda to 0.0.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pylint
-pyvda
+pyvda==0.0.8
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ future>=0.18.2
 mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
-pyvda
+pyvda==0.0.8
 six


### PR DESCRIPTION
The latest release of pyvda contains a major API rework which will break the usage in caster, and also remove support for Python 2.7.

I'm not sure what the status is of Caster re python 3 but for now I would suggest pinning to [0.0.8](https://pypi.org/project/pyvda/0.0.8/), which should work indefinitely.