### PR TITLE
Correct typo python "reper" command

### DIFF
--- a/castervoice/rules/ccr/python_rules/python.py
+++ b/castervoice/rules/ccr/python_rules/python.py
@@ -138,7 +138,7 @@ class Python(MergeRule):
     extras = [
         Dictation("text"),
         Choice("unary_meth", {
-            "reper": "reper",
+            "reper": "repr",
             "stir": "str",
             "len": "len",
         }),


### PR DESCRIPTION
I suppose this is just a typo