### PR TITLE
Prevent multiple navigation overlays from stacking

### DIFF
--- a/castervoice/lib/navigation.py
+++ b/castervoice/lib/navigation.py
@@ -25,7 +25,11 @@ initialize_clipboard()
 
 
 def mouse_alternates(mode, monitor=1, rough=True):
+    global GRID_PROCESS
     args = []
+
+    if GRID_PROCESS is not None:
+        raise Exception("Mouse navigation already in progress")
 
     if mode == "legion" and not utilities.window_exists("legiongrid", None):
         from castervoice.asynch.mouse.legion import LegionScanner
@@ -62,7 +66,6 @@ def mouse_alternates(mode, monitor=1, rough=True):
             settings.settings(["paths", "SUDOKU_PATH"]), "-g", "s", "-m",
             str(monitor)
         ]
-    global GRID_PROCESS
     GRID_PROCESS = subprocess.Popen(args) if args else None
 
 


### PR DESCRIPTION
# Title

Prevent multiple navigation overlays from stacking

<!-- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.-->

## Description

Currently it's possible to trigger multiple navigation modes at once, causing grids like rainbow and sudoku to overlap with one another. This becomes confusing because it's not obvious what order is needed to exit these grids.

This change also check to see if any other navigation mode has been started, and if so, raises an exception so that the new navigation mode doesn't wait around for its window to appear.

<!-- Describe your changes in detail -->

## Related Issue

<!-- Please reference any related issues here -->

## Motivation and Context

I keep triggering multiple ones by accident and wanted to fix it.

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Manual testing, tracking that new navigation modes can not be triggered if one is currently on the screen
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue or bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
