### PR TITLE
Remove function keys from nav2

### DIFF
--- a/castervoice/rules/core/navigation_rules/nav2.py
+++ b/castervoice/rules/core/navigation_rules/nav2.py
@@ -36,8 +36,6 @@ class NavigationNon(MappingRule):
             R(Key("cs-f")),
         "replace":
             R(Key("c-h")),
-        "F<function_key>":
-            R(Key("f%(function_key)s")),
         "[show] context menu":
             R(Key("s-f10")),
         "lean":


### PR DESCRIPTION
# Remove f keys from nav2.py

## Description

All in the title

## Related Issue

None.

## Motivation and Context

There are currently two ways to press the function keys - one in keyboard.py ("press f four") and one in nav2.py ("f four").

I think that we shouldn't have both and we should just keep the keyboard.py one. Neither are currently CCR. The F keys in nav2 do not appear to be documented anywhere.

A breaking change as users would now have to say "press f4" rather than just "f4".

## How Has This Been Tested

Trivial enough

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [x] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [x] Code is clear and readable.
