### PR TITLE
Revert "Bump pyvda from 0.0.8 to 0.2.7"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pylint
-pyvda==0.2.7
+pyvda==0.0.8
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ future>=0.18.2
 mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
-pyvda==0.2.7
+pyvda==0.0.8
 six


### PR DESCRIPTION
Reverts dictation-toolbox/Caster#923

0.0.8 is the last version that supports Python 2.7/3.X. Once Python 2.7 is dropped this dependency can be updated.