### PR TITLE
Add ubuntu terminal

### DIFF
--- a/castervoice/rules/apps/terminal/gitbash.py
+++ b/castervoice/rules/apps/terminal/gitbash.py
@@ -115,10 +115,11 @@ _executables = [
     "idea",
     "idea64",
     "studio64",
-    "pycharm"
+    "pycharm",
+    "gnome-terminal"
 ]
 
 
 def get_rule():
-    return GitBashRule, RuleDetails(name="git bash", executable=_executables)
+    return GitBashRule, RuleDetails(name="(git bash | terminal)", executable=_executables)
 


### PR DESCRIPTION
# Add ubuntu terminal and add 'terminal' as optional name for rule

## Description

This adds 'gnome-terminal' as a possible active window for the 'gitbash' rule.

## Related Issue

None

## Motivation and Context

This allows the 'gitbash' commands to be used on ubuntu without making a new rule. I believe all commands work on gnome-terminal.
 
## How Has This Been Tested

I ran this on my version of caster that includes #916. I said 'enable terminal' and 'git status'. both worked.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
