### PR TITLE
Add tcmd commands and docs

### DIFF
--- a/castervoice/rules/apps/file_manager/totalcmd_rules/totalcmd.py
+++ b/castervoice/rules/apps/file_manager/totalcmd_rules/totalcmd.py
@@ -1,4 +1,4 @@
-from dragonfly import MappingRule
+from dragonfly import MappingRule, MappingRule, Repeat, ShortIntegerRef
 from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
@@ -21,14 +21,31 @@ class TotalCommanderRule(MappingRule):
         "sort by size": R(Key('c-f6')),
         "file filter": R(Key('c-f12')),
         "new tab": R(Key('c-t')),
+        "right tab [<n>]": R(Key('c-tab') * Repeat(extra="n")),
+        "left tab [<n>]": R(Key('cs-tab') * Repeat(extra="n")),
+        'quick search': R(Key('c-s')),
         "multi rename": R(Key('c-m')),
         "display thumbnails": R(Key('cs-f1')),
         "display list": R(Key('c-f1')),
         "display details": R(Key('c-f2')),
         "display file tree": R(Key('c-f8')),
+        'pack files': R(Key('a-f5')),
+        'occupied space': R(Key('c-l')),
+        'refresh current directory': R(Key('f2')),
+        'directory content': R(Key('c-b')),
+        'selected directory contents': R(Key('cs-b')),
+        'file properties': R(Key('a-enter')),
+        'create [new] text file': R(Key('s-f4')),
     }
 
+    extras = [
+        ShortIntegerRef('n', 1, 50),
+    ]
 
+    defaults = {
+        'n': 1,
+    }
+    
 def get_rule():
     return TotalCommanderRule, RuleDetails(name="total commander", executable=["totalcmd", "totalcmd64"])
 

--- a/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
+++ b/docs/readthedocs/Caster_Commands/Application_Commands_Quick_Reference.md
@@ -184,8 +184,12 @@ Same Commands as [Git Bash](## git-bash)
 | `wipe`            | `FTP`                | `synchronize`   |
 | `sort by name`    | `sort by extension`  | `sort by date`  |
 | `sort by size`    | `file filter`        | `new tab`       |
+| `right tab [n]`    | `left tab [n]` | `quick search`  |
 | `multi rename`    | `display thumbnails` | `display list`  |
-| `display details` | `display file tree`  |                 |
+| `display details` | `display file tree`  | `pack files`    |
+| `occupied space`  | `refresh current directory`    | `directory contents` |
+| `selected directory contents` | `file properties`  | `create [new] text file`    |
+
 
 ## Total Commander: synchronize directories
 


### PR DESCRIPTION
# Several new TC commands

<!-- Provide a title for this pull request above. Is this a trivial change fixing a typo or an obvious code error? If so, insert "Trivial change" as the title and delete the remainder of the template.-->

## Description

Just a few commands using keystrokes
<!-- Describe your changes in detail -->
## How Has This Been Tested

Just rule and docs changes, tested by using
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Types of changes

<!-- What types of changes does your code introduce Put an `x` in all the boxes that apply -->
<!-- and delete the options that do not apply. -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue or bug)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Renamed existing command phrases (we discourage this without a strong rationale).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- You DO NOT NEED TO FINISH all of these to submit a pull request to Caster. -->
<!-- You may submit a pull request at any stage of completion to get feedback. -->
<!-- Please add further items to this checklist as appropriate and delete any items -->
<!-- that do not apply. If you leave the "My code implements all the features -->
<!-- I wish to merge in this pull request." box unchecked we will not review the code -->
<!-- unless requested. -->

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [ ] I have checked for and utilized existing command phrases from within Caster (delete if not applicable). 
 - Navigation commands overwrite application commands? Thought it would be the other way around, because of this tab navigation cannot just be overriden. Besides, tab movement in caster navigation currently uses ctrl+pgup/down. Not sure if it is possible, but switching to ctrl+tab/shift+tab would eliminate the need to override them in tc.
- [x] My code implements all the features I wish to merge in this pull request.
- [x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- N/A
- [ ] All new and existing tests pass.
- N/A

## Maintainer/Reviewer Checklist

<!-- Please leave these unchecked and add any other specific tasks you would like a -->
<!-- reviewer or maintainer to complete. -->

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.
