### PR TITLE
Fix virtual desktop switching on Windows 11 by using updated pyvda API

### DIFF
--- a/castervoice/lib/windows_virtual_desktops.py
+++ b/castervoice/lib/windows_virtual_desktops.py
@@ -1,29 +1,31 @@
 from dragonfly import Window, Key
 from ctypes import windll
-# https://github.com/mrob95/py-VirtualDesktopAccessor
+
+# https://github.com/mirober/pyvda
 try:
-    import pyvda  # pylint: disable=import-error
+    from pyvda import VirtualDesktop, AppView, get_virtual_desktops
 except Exception as e:
     # This could fail on linux or windows <10
     print("Importing package pyvda failed with exception %s" % str(e))
 
 ASFW_ANY = -1
 
-
 def go_to_desktop_number(n):
     # Helps make sure that the target desktop gets focus
     windll.user32.AllowSetForegroundWindow(ASFW_ANY)
-    pyvda.GoToDesktopNumber(n)
-
+    VirtualDesktop(n).go()
 
 def move_current_window_to_desktop(n=1, follow=False):
-    window_handle = Window.get_foreground().handle
-    pyvda.MoveWindowToDesktopNumber(window_handle, n)
+    hwnd = Window.get_foreground().handle
+    AppView(hwnd).move(VirtualDesktop(n))
     if follow:
         go_to_desktop_number(n)
 
-
 def close_all_workspaces():
-    total = pyvda.GetDesktopCount()
-    go_to_desktop_number(total)
-    Key("wc-f4/10:" + str(total-1)).execute()
+    desktops = get_virtual_desktops()
+    total = len(desktops)
+    if total <= 1:
+        print("Only one desktop exists; nothing to close.")
+        return
+    go_to_desktop_number(total - 1)
+    Key("wc-f4/10:" + str(total - 1)).execute()

--- a/castervoice/lib/windows_virtual_desktops.py
+++ b/castervoice/lib/windows_virtual_desktops.py
@@ -3,7 +3,7 @@ from ctypes import windll
 
 # https://github.com/mirober/pyvda
 try:
-    from pyvda import VirtualDesktop, AppView, get_virtual_desktops
+    from pyvda import VirtualDesktop, AppView, get_virtual_desktops  # pylint: disable=import-error
 except Exception as e:
     # This could fail on linux or windows <10
     print("Importing package pyvda failed with exception %s" % str(e))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,6 @@ mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
 pylint
-pyvda==0.0.8
+pyvda==0.5.0
 PySide2>=5.14
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ future>=0.18.2
 mock>=3.0.5
 appdirs>=1.4.3
 scandir>=1.10.0
-pyvda==0.0.8
+pyvda==0.5.0
 PySide2>=5.14
 six


### PR DESCRIPTION
**Reason for change:**
The outdated procedural API for `pyvda` (e.g., `pyvda.GoToDesktopNumber()`) fails on Windows 11 due to COM interface changes, resulting in the following error:
`_ctypes.COMError: (-2147467262, 'No such interface supported', (None, None, None, 0, None))`
**Changes:**
- Updated `windows_virtual_desktops.py` to use `pyvda`'s newer object-oriented API (`VirtualDesktop`, `AppView`).
- Bumped `pyvda` requirement to version `0.5.0` in `requirements.txt` and `requirements-dev.txt`.