### PR TITLE
fix: add retry logic for HUD startup to handle race conditions

### DIFF
--- a/castervoice/asynch/hud_support.py
+++ b/castervoice/asynch/hud_support.py
@@ -1,4 +1,4 @@
-import sys, subprocess, json
+import sys, subprocess, json, time
 
 from dragonfly import CompoundRule, MappingRule, get_current_engine, Function
 
@@ -106,13 +106,22 @@ class HudPrintMessageHandler(printer.BaseMessageHandler):
         super(HudPrintMessageHandler, self).__init__()
         self.hud = control.nexus().comm.get_com("hud")
         self.is_hud_active = False
-        try:
-            if get_current_engine().name != "text":
-                self.hud.ping() # HUD running?
-                self.is_hud_active = True
-        except Exception as e:
-            self.is_hud_active = False
-            printer.out("Hud not available. \n{}".format(e))
+        
+        if get_current_engine().name != "text":
+            # Retry loop to handle the cold-boot race condition
+            max_retries = 10
+            for attempt in range(max_retries):
+                try:
+                    self.hud.ping() # HUD running?
+                    self.is_hud_active = True
+                    break # Connection successful, break out of loop
+                except Exception as e:
+                    if attempt < max_retries - 1:
+                        time.sleep(0.5) # Wait 500ms before next attempt
+                    else:
+                        # Log failure if it still won't connect after 5 seconds
+                        self.is_hud_active = False
+                        printer.out("Hud not available after {} retries. \n{}".format(max_retries, e))
 
     def handle_message(self, items):
         if self.is_hud_active is True:


### PR DESCRIPTION
# Fix HUD connection race condition on cold boot

## Description

I've updated `HudPrintMessageHandler` to include a retry loop when establishing the initial connection to the HUD process. Instead of failing instantly on the first ping, the handler will now poll for a connection up to 10 times with a 0.5-second delay. The hope is that this gives the OS enough time to spin up the background process and bind the port before Caster gives up and flags the HUD as inactive.

## Related Issue

Fixes #920

## Motivation and Context

After running into this issue and discussing it with an LLM, I suspect this might be a race condition occurring on a cold startup. It seems like when running Caster for the first time after a boot, `start_hud` launches the HUD via `subprocess.Popen`, but the main Caster thread continues executing and attempts to ping the HUD before the OS has fully opened the port. 

This appears to result in the `[WinError 10061] Connection Refused` error, leaving a blank white HUD window. Restarting Caster usually bypasses the error, likely due to OS caching making the process load much faster the second time around. This fix is an attempt to ensure Caster gracefully waits for the HUD to wake up before throwing the error.

<img width="1495" height="815" alt="hud-error" src="https://github.com/user-attachments/assets/51f6e945-c407-4269-8191-77985c0c2576" />


## How Has This Been Tested

Tested by observing Caster's initial startup immediately following a full system reboot. It appears that the new polling loop successfully catches the delay, waits for the port to open, and connects to the HUD GUI, avoiding the instant `[WinError 10061]` failure I was seeing previously.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have checked that my code does not duplicate functionality elsewhere in Caster.
- [x] My code implements all the features I wish to merge in this pull request.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.

## Maintainer/Reviewer Checklist

- [ ] Basic functionality has been tested and works as claimed.
- [ ] New documentation is clear and complete.
- [ ] Code is clear and readable.