### PR TITLE
Fix 4-digit length restriction bug in numb command

### DIFF
--- a/castervoice/rules/core/numbers_rules/numeric.py
+++ b/castervoice/rules/core/numbers_rules/numeric.py
@@ -1,4 +1,4 @@
-from dragonfly import Choice, Function, ShortIntegerRef
+from dragonfly import Choice, Function, ShortIntegerRef, NumberRef
 
 try:  # Try first loading from caster user directory
     from numeric_support import word_number, numbers2
@@ -24,7 +24,7 @@ class Numbers(MergeRule):
 
     extras = [
         ShortIntegerRef("wn", 0, 10),
-        ShortIntegerRef("wnKK", 0, 1000000),
+        NumberRef("wnKK", zero=True),
         Choice(
             "long", {
                 "long": " ",


### PR DESCRIPTION
# Fix 4-digit length restriction bug in numb command

PR description written with Agent in Antigravity IDE

## Description

Migrates the `wnKK` extra in `castervoice/rules/core/numbers_rules/numeric.py` from `ShortIntegerRef` to `NumberRef("wnKK", zero=True)`. This resolves digit sequence length constraints and allows arbitrary strings of digits to be dictated up to Dragonfly's maximum series length (7 digits). 

*Note: This change alone does not resolve the leading zero truncation issue (e.g. dictating `"numb zero one one"` will still print `"11"` because the leading zero is mathematically dropped by unmodified Dragonfly).*

## Related Issue

- Resolves: dictation-toolbox/Caster#857
- Related to: dictation-toolbox/Caster#938

## Motivation and Context

- **Why this change is required**: `ShortIntegerRef` is designed for shorthand magnitudes, which restricts the engine from cleanly parsing arbitrary sequential digit dictations longer than 4 characters (e.g., `"one two three four five"`). 
- **What it solves**: By switching to `NumberRef`, the parsing is delegated to Dragonfly's native loop-based `Repetition` grammar, extending the length limit to 7 digits.
- **Dragonfly Dependency**: To fully resolve the leading zero truncation (e.g., preserving `"011"`), this PR should be paired with the proposed Dragonfly fix (see [https://github.com/dictation-toolbox/dragonfly/pull/409](https://github.com/dictation-toolbox/dragonfly/pull/409)) that implements a custom `StringInt` return type. However, even without the Dragonfly patch, this PR stands alone as a valuable upgrade by immediately resolving the digit length limit (#857).

## How Has This Been Tested

- Tested locally within Caster using Kaldi back end. 
- Dictating `"numb one two three four five six seven"` successfully parsed and typed out the full sequence.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue or bug)

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My code implements all the features I wish to merge in this pull request.

## Video Demo

In the demo, I'm using baseline Dragonfly, not the other fix I proposed in dragonfly PR 409. This shows this number fix works independently for length limit but not leading zeroes getting chopped off.

https://github.com/user-attachments/assets/fabf7c05-eebd-47b1-ae67-6387f87c4c2c

